### PR TITLE
Added closing in a state when press the confirm button in the modal.

### DIFF
--- a/EventsExpress/ClientApp/src/components/event/simple-modal.js
+++ b/EventsExpress/ClientApp/src/components/event/simple-modal.js
@@ -4,7 +4,6 @@ import DialogActions from "@material-ui/core/DialogActions";
 import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import { DialogContent } from '@material-ui/core';
-import { setEventCanelationModalStatus } from '../../actions/event-item-view';
 
 export default class SimpleModal extends Component {
     constructor(props) {
@@ -22,6 +21,11 @@ export default class SimpleModal extends Component {
 
     onClose = () => {
         this.setState({isOpen: false, id: null});
+    }
+
+    onConfirm = () => {
+        this.props.action(this.props.id)
+        this.setState({ isOpen: false });
     }
 
     render() {
@@ -52,7 +56,7 @@ export default class SimpleModal extends Component {
                                 type="button"
                                 value="Login"
                                 color="primary"
-                                onClick={() => this.props.action(this.props.id)}
+                                onClick={this.onConfirm}
                             >
                                 confirm
                             </Button>


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @iuriikhrystiuk 

### Second Level Review

- [ ] @Andriets 

## Summary of issue

The modal does not close after raising or dropping the user of the event

## Summary of change

Added separate function with the closing state in confirm button.

## Testing approach

Test approving users to owners of event, when more than 2 users.
Test denying owner from an event, when existing more than 2 owners.

## CHECK LIST
- [x]  Сode coverage >=6.74%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
