### PR TITLE
Fixed: Wrong Alignment Of The UserName in profile

### DIFF
--- a/EventsExpress/ClientApp/src/components/header-profile/header-profile.css
+++ b/EventsExpress/ClientApp/src/components/header-profile/header-profile.css
@@ -29,3 +29,8 @@
     width: 75px !important;
     height: 75px !important;
 }
+
+ .user-name {
+    padding: 10px;
+    overflow-wrap: anywhere;
+}

--- a/EventsExpress/ClientApp/src/components/header-profile/header-profile.js
+++ b/EventsExpress/ClientApp/src/components/header-profile/header-profile.js
@@ -25,7 +25,7 @@ export default class HeaderProfile extends Component {
                     {id && (
                         <div className="d-flex flex-column align-items-center">
                             <CustomAvatar size="big" photoUrl={photoUrl} name={this.props.user.name} />
-                            <h4>{name}</h4>
+                            <h4 className="user-name">{name}</h4>
                             <RatingAverage value={rating} direction='row' />
                             <div>
                                 <Link to={'/profile'}>


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/ita-social-projects/EventsExpress/issues/357)


## Code reviewers

- [ ] @iuriikhrystiuk 

### Second Level Review

- [ ] @sand0 

## Summary of issue

Wrong alignment of the user's name on the "header-profile"

## Summary of change

- Added padding for user name
- Added text wrap for user name

## Testing approach

Check long user name in header-profile

## CHECK LIST
- [ ]  Сode coverage >=7.25%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
