### PR TITLE
Fixed: The rating of the event attended is not saved

### DIFF
--- a/EventsExpress/ClientApp/src/actions/rating.js
+++ b/EventsExpress/ClientApp/src/actions/rating.js
@@ -25,9 +25,8 @@ const api_serv = new EventService();
 export function set_rating(data) {
     return dispatch => {
         dispatch(setRatingPending(true));
-
-        const res = api_serv.setRate(data);      
-        return res.then(responce => {
+    
+        return api_serv.setRate(data).then(responce => {
             if (responce.error == null) {
                 dispatch(setRatingSuccess(responce));
                 dispatch(getRatingSuccess(data.rate));
@@ -47,9 +46,7 @@ export function get_currrent_rating(data) {
     return dispatch => {
         dispatch(getRatingPending(true));
 
-        const res = api_serv.getCurrentRate(data);
-        
-        res.then(responce => {
+        api_serv.getCurrentRate(data).then(responce => {
             if (responce.error == null) {
                 dispatch(getRatingSuccess(responce));
             } else {
@@ -67,9 +64,7 @@ export function get_average_rating(data) {
     return dispatch => {
         dispatch(getAverageRatingPending(true));
 
-        const res = api_serv.getAverageRate(data);
-        
-        res.then(responce => {
+        api_serv.getAverageRate(data).then(responce => {
             if (responce.error == null) {
                 dispatch(getAverageRatingSuccess(responce));
             } else {

--- a/EventsExpress/ClientApp/src/actions/rating.js
+++ b/EventsExpress/ClientApp/src/actions/rating.js
@@ -1,4 +1,5 @@
 import { EventService } from '../services';
+import { setAlert } from './alert'
 
 export const getRate = {
     PENDING: 'GET_RATE_PENDING',
@@ -26,13 +27,16 @@ export function set_rating(data) {
         dispatch(setRatingPending(true));
 
         const res = api_serv.setRate(data);      
-        res.then(response => {
-            if (response.error == null) {
-                dispatch(setRatingSuccess(response));
+        return res.then(responce => {
+            if (responce.error == null) {
+                dispatch(setRatingSuccess(responce));
                 dispatch(getRatingSuccess(data.rate));
-                
+                return Promise.resolve();
             } else {
-                dispatch(setRatingError(response.error));
+                dispatch(setAlert({
+                    variant: 'error',
+                    message: responce.error
+                }));
             }
         });
     }
@@ -45,11 +49,14 @@ export function get_currrent_rating(data) {
 
         const res = api_serv.getCurrentRate(data);
         
-        res.then(response => {
-            if (response.error == null) {
-                dispatch(getRatingSuccess(response));
+        res.then(responce => {
+            if (responce.error == null) {
+                dispatch(getRatingSuccess(responce));
             } else {
-                dispatch(getRatingError(response.error));
+                dispatch(setAlert({
+                    variant: 'error',
+                    message: responce.error
+                }));
             }
         });
     }
@@ -62,11 +69,14 @@ export function get_average_rating(data) {
 
         const res = api_serv.getAverageRate(data);
         
-        res.then(response => {
-            if (response.error == null) {
-                dispatch(getAverageRatingSuccess(response));
+        res.then(responce => {
+            if (responce.error == null) {
+                dispatch(getAverageRatingSuccess(responce));
             } else {
-                dispatch(getAverageRatingError(response.error));
+                dispatch(setAlert({
+                    variant: 'error',
+                    message: responce.error
+                }));
             }
         });
     }

--- a/EventsExpress/ClientApp/src/containers/rating.js
+++ b/EventsExpress/ClientApp/src/containers/rating.js
@@ -14,9 +14,7 @@ class RatingWrapper extends Component{
 
     onRateChange = event => {
         let rate = event.currentTarget.value;
-        
-        this.props.setRate(rate); 
-        setTimeout(this.props.getAverageRate, 125);
+        this.props.setRate(rate).then(this.props.getAverageRate);
     }
 
     render() {        

--- a/EventsExpress/ClientApp/src/services/EventService.js
+++ b/EventsExpress/ClientApp/src/services/EventService.js
@@ -133,7 +133,7 @@ export default class EventService {
 
     setRate = async (data) => {
         const res = await baseService.setResource('event/setrate', {
-            rate: data.rate,
+            rate: Number(data.rate),
             userId: data.userId,
             eventId: data.eventId
         });


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/ita-social-projects/EventsExpress/issues/376)


## Code reviewers

- [x] @iuriikhrystiuk 

### Second Level Review

- [ ] @sand0 

## Summary of issue

The rating of the event attended is not saved and is not highlighted by active star icons

## Summary of change

- Converted rate to Number type
- Fixed error message displaying

## Testing approach

Set rate for visited event

## CHECK LIST
- [ ]  Сode coverage >=___%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
