### PR TITLE
Fixed date picker incorrectly drops

### DIFF
--- a/EventsExpress/ClientApp/src/components/event/event-form.css
+++ b/EventsExpress/ClientApp/src/components/event/event-form.css
@@ -143,3 +143,7 @@
 .select-style select:focus {
     outline: none;
 }
+
+.react-datepicker-popper {
+    z-index: 460;
+}


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/ita-social-projects/EventsExpress/issues/391)


## Code reviewers

- [x] @iuriikhrystiuk 

### Second Level Review

- [ ] @sand0 

## Summary of issue

The date picker incorrectly drops between the blocks with the description and the map on the 'Add Event' page.

## Summary of change

changed incorrectly drops (increased z-index)

## Testing approach



## CHECK LIST
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
