### PR TITLE
The '+' sign has been replaced with the 'Add category' caption on the Categories admin panel

### DIFF
--- a/EventsExpress/ClientApp/src/components/category/category-list.js
+++ b/EventsExpress/ClientApp/src/components/category/category-list.js
@@ -13,11 +13,11 @@ export default class CategoryList extends Component {
         return (
             <>
                 <tr>
-
                     <td>Name</td>
                     <td className="d-flex align-items-center justify-content-center">Users</td>
                     <td className="justify-content-center">Events</td>
-
+                    <td></td>
+                    <td></td>
                 </tr>
                 {this.renderItems(data_list)}
             </>);

--- a/EventsExpress/ClientApp/src/components/event/RenderList.js
+++ b/EventsExpress/ClientApp/src/components/event/RenderList.js
@@ -15,6 +15,7 @@ class RenderList extends Component {
         const { page, totalPages, data_list } = this.props;
 
         return <>
+            <div className="row">
                 {data_list.length > 0
                     ? this.renderItems(data_list)
                     : <div id="notfound" className="w-100">
@@ -24,6 +25,7 @@ class RenderList extends Component {
                             </div>
                         </div>
                     </div>}
+            </div>
             <br />
             {totalPages > 1 &&
                 <PagePagination

--- a/EventsExpress/ClientApp/src/containers/categories/category-add.js
+++ b/EventsExpress/ClientApp/src/containers/categories/category-add.js
@@ -1,7 +1,6 @@
 ﻿import React from "react";
 import { connect } from "react-redux";
 import { reset } from 'redux-form';
-import IconButton from "@material-ui/core/IconButton";
 import add_category,
 {
     setCategoryPending,
@@ -30,13 +29,10 @@ class CategoryAddWrapper extends React.Component {
         return (this.props.item.id !== this.props.editedCategory)
             ? <tr>
                 <td className="align-middle align-items-stretch" width="20%">
-                    <div className="d-flex align-items-center justify-content-center">
-                        <IconButton
-                            className="text-info"
-                            onClick={this.props.set_category_edited}
-                        >
-                            <i className="fas fa-plus-circle"></i>
-                        </IconButton>
+                    <div className="d-flex align-items-center justify-content-left">
+                        <button className="btn btn-outline-primary ml-0" onClick={this.props.set_category_edited}>
+                            Add category
+                        </button>
                     </div>
                 </td>
                 <td width="55%"></td>


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [x] @iuriikhrystiuk

### Second Level Review

- [ ] @sand0

## Summary of issue

Button with the '+' sign is presented. The “+” sign must be replaced with a button labeled “Add category”. 

## Summary of change

The '+' sign has been replaced with the 'Add category' caption. 
Changed the button style. 
Fixed UI issues related to missing <td> tags in the table. 
Fixed UI issue with displaying the list of events on the 'Home' / 'Draft' page. 

## Testing approach

Tested manually.

## CHECK LIST
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
