### PR TITLE
Fix correct answer from backend if password was input incorrectly

### DIFF
--- a/EventsExpress.Core/Services/AuthService.cs
+++ b/EventsExpress.Core/Services/AuthService.cs
@@ -102,7 +102,7 @@ namespace EventsExpress.Core.Services
 
             if (!VerifyPassword(account.AuthLocal, password))
             {
-                throw new EventsExpressException("Incorrect login or password1");
+                throw new EventsExpressException("Incorrect login or password");
             }
 
             // authentication successful so generate jwt and refresh tokens

--- a/EventsExpress.Test/ServiceTests/AuthServiceTests.cs
+++ b/EventsExpress.Test/ServiceTests/AuthServiceTests.cs
@@ -219,7 +219,7 @@ namespace EventsExpress.Test.ServiceTests
                 await service.Authenticate(existingEmail, invalidPassword);
 
             var ex = Assert.ThrowsAsync<EventsExpressException>(methodInvoke);
-            Assert.That(ex.Message.Contains("Incorrect login or password1"));
+            Assert.That(ex.Message.Contains("Incorrect login or password"));
             mockTokenService.Verify(s => s.GenerateRefreshToken(), Times.Never);
         }
 

--- a/EventsExpress/Filters/EventsExpressExceptionFilterAttribute.cs
+++ b/EventsExpress/Filters/EventsExpressExceptionFilterAttribute.cs
@@ -19,7 +19,7 @@ namespace EventsExpress.Filters
                         { string.Empty, new[] { eventsExpressException.Message } },
                     },
                 };
-                if (eventsExpressException.ValidationErrors.Count > 0)
+                if (eventsExpressException.ValidationErrors != null && eventsExpressException.ValidationErrors.Count > 0)
                 {
                     foreach (var x in eventsExpressException.ValidationErrors)
                     {


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @iuriikhrystiuk 

### Second Level Review

- [ ] @sand0 

## Summary of issue

500 Internal Server Error appears during trying to 'Sign In' into the application

## Summary of change

Fixed conditions in EventsExpressExceptionFilterAttribute

## Testing approach

Manual tested

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
