### PR TITLE
'take item' button correct work

### DIFF
--- a/EventsExpress.Db/DbInitialize/DbInitializer.cs
+++ b/EventsExpress.Db/DbInitialize/DbInitializer.cs
@@ -96,16 +96,51 @@ namespace EventsExpress.Db.DbInitialize
 
             dbContext.Categories.AddRange(categories);
 
-            var categoriesOfMeasuring = new CategoryOfMeasuring[]
-           {
-                new CategoryOfMeasuring { CategoryName = "Weight" },
-                new CategoryOfMeasuring { CategoryName = "Liquids" },
-                new CategoryOfMeasuring { CategoryName = "Points" },
-                new CategoryOfMeasuring { CategoryName = "Length" },
-                new CategoryOfMeasuring { CategoryName = "Other" },
-           };
+            var unitsOfMeasuring = new UnitOfMeasuring[]
+            {
+                new UnitOfMeasuring
+                {
+                    UnitName = "Kilogram",
+                    ShortName = "kg",
+                    IsDeleted = false,
+                    Category = new CategoryOfMeasuring
+                    {
+                        CategoryName = "Weight",
+                    },
+                },
+                new UnitOfMeasuring
+                {
+                    UnitName = "Meter",
+                    ShortName = "m",
+                    IsDeleted = false,
+                    Category = new CategoryOfMeasuring
+                    {
+                        CategoryName = "Length",
+                    },
+                },
+                new UnitOfMeasuring
+                {
+                    UnitName = "Liter",
+                    ShortName = "l",
+                    IsDeleted = false,
+                    Category = new CategoryOfMeasuring
+                    {
+                        CategoryName = "Liquids",
+                    },
+                },
+                new UnitOfMeasuring
+                {
+                    UnitName = "Piece",
+                    ShortName = "pc",
+                    IsDeleted = false,
+                    Category = new CategoryOfMeasuring
+                    {
+                        CategoryName = "Quantity",
+                    },
+                },
+            };
 
-            dbContext.CategoriesOfMeasurings.AddRange(categoriesOfMeasuring);
+            dbContext.UnitOfMeasurings.AddRange(unitsOfMeasuring);
 
             var emailMessages = new[]
             {

--- a/EventsExpress.Db/DbInitialize/DbInitializer.cs
+++ b/EventsExpress.Db/DbInitialize/DbInitializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using EventsExpress.Db.Bridge;
 using EventsExpress.Db.EF;
@@ -7,6 +8,7 @@ using EventsExpress.Db.Enums;
 
 namespace EventsExpress.Db.DbInitialize
 {
+    [ExcludeFromCodeCoverage]
     public static class DbInitializer
     {
         public static void Seed(AppDbContext dbContext, IPasswordHasher passwordHasher)

--- a/EventsExpress/ClientApp/src/components/inventory/VisitorSeeItem.js
+++ b/EventsExpress/ClientApp/src/components/inventory/VisitorSeeItem.js
@@ -63,7 +63,7 @@ export default class VisitorSeeItem extends Component {
                                 <Tooltip title="Will take" placement="right-start">
                                     <IconButton
                                         disabled={disabledEdit}
-                                        onClick={this.props.markItemAsWillTake}>
+                                        onClick={markItemAsEdit}>
                                         <i className="fa-sm fas fa-plus text-success" />
                                     </IconButton>
                                 </Tooltip>

--- a/EventsExpress/ClientApp/src/containers/inventory-item.js
+++ b/EventsExpress/ClientApp/src/containers/inventory-item.js
@@ -133,11 +133,9 @@ class InventoryItemWrapper extends Component {
                 <VisitorEditItemForm
                     onSubmit={this.onWillTake}
                     onCancel={this.onCancel}
-                    alreadyGet={alreadyGet - (usersInventories.data.reduce((acc, cur) => {
-                        if (cur.inventoryId === item.id && cur.userId === user.id)
-                            return acc + cur.quantity
-                        else return acc
-                    }, 0)) || 0}
+                    alreadyGet={alreadyGet - (usersInventories.data.find(e => e.userId === user.Id && e.inventoryId === item.id) === undefined
+                        ? 0
+                        : usersInventories.data.find(e => e.userId === user.Id && e.inventoryId === item.id).quantity)}
                     initialValues={item}
                 />
             }

--- a/EventsExpress/ClientApp/src/containers/inventory-item.js
+++ b/EventsExpress/ClientApp/src/containers/inventory-item.js
@@ -24,15 +24,13 @@ class InventoryItemWrapper extends Component {
         this.onWillTake = this.onWillTake.bind(this);
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
-        if (this.props === nextProps && this.state === nextState)
-            return false
-        if (this.props.usersInventories.isPending !== nextProps.usersInventories.isPending) {
-            const { item, user } = nextProps
-            if (!this.state.isWillTake && nextProps.usersInventories.data.some(e => e.userId === user.id && e.inventoryId === item.id))
+    componentDidUpdate(prevProps) {
+        const { usersInventories } = this.props
+        if (usersInventories.isPending !== prevProps.usersInventories.isPending) {
+            const { item, user } = this.props
+            if (!this.state.isWillTake && usersInventories.data.some(e => e.userId === user.id && e.inventoryId === item.id))
                 this.onAlreadyGet()
         }
-        return true
     }
 
     onAlreadyGet = () => {
@@ -113,6 +111,14 @@ class InventoryItemWrapper extends Component {
         this.props.delete_users_inventory(data);
     }
 
+    getItemsTakenByUserQuantity() {
+        const { item, user, usersInventories } = this.props
+        const itemsQuantity = usersInventories.data.find(e => e.userId === user.id && e.inventoryId === item.id)
+        return itemsQuantity === undefined
+            ? 0
+            : itemsQuantity.quantity
+    }
+
     render() {
         const { item, user, usersInventories, isMyEvent, disabledEdit } = this.props;
         const alreadyGet = usersInventories.data.reduce((acc, cur) => {
@@ -133,9 +139,7 @@ class InventoryItemWrapper extends Component {
                 <VisitorEditItemForm
                     onSubmit={this.onWillTake}
                     onCancel={this.onCancel}
-                    alreadyGet={alreadyGet - (usersInventories.data.find(e => e.userId === user.Id && e.inventoryId === item.id) === undefined
-                        ? 0
-                        : usersInventories.data.find(e => e.userId === user.Id && e.inventoryId === item.id).quantity)}
+                    alreadyGet={alreadyGet - this.getItemsTakenByUserQuantity()}
                     initialValues={item}
                 />
             }


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @iuriikhrystiuk

### Second Level Review

- [ ] @sand0

## Summary of issue

Fixed 'Add item' button logic for non event-master user

## Summary of change

1. Added shouldComponentUpdate for check if user already taken the item
2. Remove unnecessary markItemAsWillTake
3. Fixed InventoryItemWrapper functions logic
4. Added seeding for unitsOfMeasuring into DbInitializer 

## Testing approach

ToDo

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
