### PR TITLE
Register complete improvement

### DIFF
--- a/EventsExpress.Core/DTOs/RegisterBindDTO.cs
+++ b/EventsExpress.Core/DTOs/RegisterBindDTO.cs
@@ -1,0 +1,13 @@
+﻿using EventsExpress.Db.Enums;
+
+namespace EventsExpress.Core.DTOs
+{
+    public class RegisterBindDto
+    {
+        public string Email { get; set; }
+
+        public string Password { get; set; }
+
+        public AuthExternalType Type { get; set; }
+    }
+}

--- a/EventsExpress.Core/IServices/IAuthService.cs
+++ b/EventsExpress.Core/IServices/IAuthService.cs
@@ -13,6 +13,8 @@ namespace EventsExpress.Core.IServices
 
         Task<AuthenticateResponseModel> Authenticate(string email, AuthExternalType type);
 
+        Task<AuthenticateResponseModel> BindExternalAccount(RegisterBindDto registerBindDto);
+
         Task<AuthenticateResponseModel> EmailConfirmAndAuthenticate(Guid authLocalId, string token);
 
         Task<bool> CanRegister(string email);

--- a/EventsExpress.Core/Services/AuthService.cs
+++ b/EventsExpress.Core/Services/AuthService.cs
@@ -160,8 +160,8 @@ namespace EventsExpress.Core.Services
 
             var authExternal = externalAccount.AuthExternal.First();
             authExternal.AccountId = localAccount.Id;
-            localAccount.AuthExternal.Append(authExternal);
 
+            Context.RefreshTokens.RemoveRange(externalAccount.RefreshTokens);
             Context.Accounts.Remove(externalAccount);
 
             await Context.SaveChangesAsync();

--- a/EventsExpress.Test/ControllerTests/AuthenticationControllerTests.cs
+++ b/EventsExpress.Test/ControllerTests/AuthenticationControllerTests.cs
@@ -247,6 +247,31 @@ namespace EventsExpress.Test.ControllerTests
         }
 
         [Test]
+        [Category("RegisterBindExternalAccount")]
+        public void RegisterBind_CantBindAccount_ThrowExceptionAsync()
+        {
+            _authService.Setup(s => s.BindExternalAccount(It.IsAny<RegisterBindDto>())).Throws<EventsExpressException>();
+
+            Assert.ThrowsAsync<EventsExpressException>(() =>
+            _authenticationController.RegisterBindExternalAccount(new RegisterBindViewModel()));
+            _tokenService.Verify(s => s.SetTokenCookie(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        [Category("RegisterBindExternalAccount")]
+        public async Task RegisterBind_AllOk_DoesNotThrowExceptionAsync()
+        {
+            _authService.Setup(s => s.BindExternalAccount(It.IsAny<RegisterBindDto>())).ReturnsAsync(new AuthenticateResponseModel(It.IsAny<string>(), It.IsAny<string>()));
+
+            var res = await _authenticationController.RegisterBindExternalAccount(new RegisterBindViewModel());
+
+            Assert.DoesNotThrowAsync(() => Task.FromResult(res));
+            Assert.IsInstanceOf<OkObjectResult>(res);
+            _authService.Verify(s => s.BindExternalAccount(It.IsAny<RegisterBindDto>()), Times.Once);
+            _tokenService.Verify(s => s.SetTokenCookie(It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
         [Category("RegisterComplete")]
         public void RegisterComplete_CantMap_ThrowException()
         {

--- a/EventsExpress.Test/ValidationTests/RegisterCompleteViewModelValidatorTests.cs
+++ b/EventsExpress.Test/ValidationTests/RegisterCompleteViewModelValidatorTests.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using EventsExpress.Db.Enums;
+using EventsExpress.Validation;
+using EventsExpress.ViewModels;
+using FluentValidation;
+using FluentValidation.TestHelper;
+using NUnit.Framework;
+
+namespace EventsExpress.Test.ValidationTests
+{
+    [TestFixture]
+    internal class RegisterCompleteViewModelValidatorTests
+    {
+        private IValidator<RegisterCompleteViewModel> validator;
+        private RegisterCompleteViewModel model;
+
+        [SetUp]
+        public void Setup()
+        {
+            validator = new RegisterCompleteViewModelValidator();
+            model = new RegisterCompleteViewModel
+            {
+                Birthday = new DateTime(2000, 1, 1),
+                Email = "correct@mail.com",
+                Gender = Gender.Male,
+                Phone = "+380123456789",
+                Username = "Username",
+            };
+        }
+
+        [Test]
+        [Category("Birthday validation")]
+        public void ShoudNotHaveError_BirthdayIsCorrect()
+        {
+            var result = validator.TestValidate(model);
+
+            result.ShouldNotHaveValidationErrorFor(m => m.Birthday);
+        }
+
+        [Test]
+        [Category("Birthday validation")]
+        public void ShouldHaveError_BirthdayIsDefaultValue()
+        {
+            model.Birthday = default;
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Birthday).WithErrorMessage("Birthday date is required");
+        }
+
+        [Test]
+        [Category("Birthday validation")]
+        public void ShouldHaveError_BirthdayIsOutOfRange()
+        {
+            model.Birthday = DateTime.Now;
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Birthday).WithErrorMessage("Birthday date is not correct");
+        }
+
+        [Test]
+        [Category("Email validation")]
+        public void ShouldNotHaveError_EmailIsCorrect()
+        {
+            var result = validator.TestValidate(model);
+
+            result.ShouldNotHaveValidationErrorFor(m => m.Email);
+        }
+
+        [Test]
+        [Category("Email validation")]
+        public void ShouldHaveError_EmailIsDefault()
+        {
+            model.Email = default;
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Email).WithErrorMessage("Email address is required");
+        }
+
+        [Test]
+        [Category("Email validation")]
+        public void ShouldHaveError_EmailIsNotAnEmailAddress()
+        {
+            model.Email = "IsNotAnEmailAddress";
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Email).WithErrorMessage("Email address is not correct");
+        }
+
+        [Test]
+        [Category("Gender validation")]
+        public void ShouldNotHaveError_GenderIsCorrect()
+        {
+            var result = validator.TestValidate(model);
+
+            result.ShouldNotHaveValidationErrorFor(m => m.Gender);
+        }
+
+        [Test]
+        [Category("Gender validation")]
+        public void ShouldHaveError_GenderIsDefaultDefault()
+        {
+            model.Gender = default;
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Gender).WithErrorMessage("Gender is required");
+        }
+
+        [Test]
+        [Category("Gender validation")]
+        public void ShouldHaveError_GenderIsOutOfEnum()
+        {
+            model.Gender = (Gender)4;
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Gender).WithErrorMessage("Gender is not correct");
+        }
+
+        [Test]
+        [Category("Phone validation")]
+        public void ShouldNotHaveError_PhoneIsCorrect()
+        {
+            var result = validator.TestValidate(model);
+
+            result.ShouldNotHaveValidationErrorFor(m => m.Phone);
+        }
+
+        [Test]
+        [Category("Phone validation")]
+        public void ShouldHaveError_PhoneIsEmpty()
+        {
+            model.Phone = string.Empty;
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Phone).WithErrorMessage("Phonenumber is required");
+        }
+
+        [Test]
+        [Category("Phone validation")]
+        public void ShouldHaveError_PhoneIsNotAPhonenumber()
+        {
+            model.Phone = "IsNotAPhonenumber";
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Phone).WithErrorMessage("Phonenumber is not correct");
+        }
+
+        [Test]
+        [Category("Username validation")]
+        public void ShouldNotHaveError_UsernameIsCorrect()
+        {
+            var result = validator.TestValidate(model);
+
+            result.ShouldNotHaveValidationErrorFor(m => m.Username);
+        }
+
+        [Test]
+        [Category("Username validation")]
+        public void ShouldHaveError_UsernameIsDefault()
+        {
+            model.Username = default;
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Username).WithErrorMessage("Username is required");
+        }
+
+        [Test]
+        [Category("Username validation")]
+        public void ShouldHaveError_UsernameIsTooShort()
+        {
+            model.Username = "TS";
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Username).WithErrorMessage("Username is too short");
+        }
+
+        [Test]
+        [Category("Username validation")]
+        public void ShouldHaveError_UsernameIsTooLong()
+        {
+            model.Username = "ThereAreTooLongUsernameSoLongThatValidationWillFailed";
+
+            var result = validator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(m => m.Username).WithErrorMessage("Username is too long");
+        }
+    }
+}

--- a/EventsExpress/ClientApp/src/actions/login/login-action.js
+++ b/EventsExpress/ClientApp/src/actions/login/login-action.js
@@ -40,7 +40,7 @@ export function loginFacebook(profile) {
     const call = () => api_serv.setFacebookLogin({
         Email: profile.email,
         Name: profile.name,
-        PhotoUrl: profile.picture
+        PhotoUrl: profile.picture.data.url
     });
     return loginResponseHandler(call, {email: profile.email, name: profile.name, birthday: profile.birthday, gender: profile.gender});
 }

--- a/EventsExpress/ClientApp/src/actions/login/login-action.js
+++ b/EventsExpress/ClientApp/src/actions/login/login-action.js
@@ -33,7 +33,7 @@ export function loginGoogle(tokenId, profile) {
         Name: profile.name,
         PhotoUrl: profile.imageUrl
     });
-    return loginResponseHandler(call, {email: profile.email, name: profile.name});
+    return loginResponseHandler(call, {email: profile.email, name: profile.name, type: 0});
 }
 
 export function loginFacebook(profile) {
@@ -42,7 +42,7 @@ export function loginFacebook(profile) {
         Name: profile.name,
         PhotoUrl: profile.picture.data.url
     });
-    return loginResponseHandler(call, {email: profile.email, name: profile.name, birthday: profile.birthday, gender: profile.gender});
+    return loginResponseHandler(call, {email: profile.email, name: profile.name, birthday: profile.birthday, gender: profile.gender, type: 1});
 }
 
 export function loginTwitter(data) {
@@ -54,7 +54,7 @@ export function loginTwitter(data) {
         Name: typeof data.name !== 'undefined' ? data.name : data.screen_name,
         PhotoUrl: data.image_url,
     });
-    return loginResponseHandler(res, {email: data.email, name: typeof data.name !== 'undefined' ? data.name : data.screen_name});
+    return loginResponseHandler(res, {email: data.email, name: typeof data.name !== 'undefined' ? data.name : data.screen_name, type: 2});
 }
 
 export function loginAfterEmailConfirmation(data) {

--- a/EventsExpress/ClientApp/src/actions/login/login-action.js
+++ b/EventsExpress/ClientApp/src/actions/login/login-action.js
@@ -26,23 +26,23 @@ export default function login(email, password) {
     return loginResponseHandler(call);
 }
 
-export function loginGoogle(tokenId, email, name, imageUrl) {
+export function loginGoogle(tokenId, profile) {
     const call = () => api_serv.setGoogleLogin({
         TokenId: tokenId,
-        Email: email,
-        Name: name,
-        PhotoUrl: imageUrl
+        Email: profile.email,
+        Name: profile.name,
+        PhotoUrl: profile.imageUrl
     });
-    return loginResponseHandler(call);
+    return loginResponseHandler(call, {email: profile.email, name: profile.name});
 }
 
-export function loginFacebook(email, name, picture) {
+export function loginFacebook(profile) {
     const call = () => api_serv.setFacebookLogin({
-        Email: email,
-        Name: name,
-        PhotoUrl: picture
+        Email: profile.email,
+        Name: profile.name,
+        PhotoUrl: profile.picture
     });
-    return loginResponseHandler(call);
+    return loginResponseHandler(call, {email: profile.email, name: profile.name, birthday: profile.birthday, gender: profile.gender});
 }
 
 export function loginTwitter(data) {
@@ -54,7 +54,7 @@ export function loginTwitter(data) {
         Name: typeof data.name !== 'undefined' ? data.name : data.screen_name,
         PhotoUrl: data.image_url,
     });
-    return loginResponseHandler(res);
+    return loginResponseHandler(res, {email: data.email, name: typeof data.name !== 'undefined' ? data.name : data.screen_name});
 }
 
 export function loginAfterEmailConfirmation(data) {
@@ -68,7 +68,7 @@ export function loginAfterEmailConfirmation(data) {
     }
 }
 
-export function getUserInfo() {
+export function getUserInfo(profile) {
     return async dispatch => {
         let response = await api_serv.getUserInfo();
         if (!response.ok) {
@@ -77,7 +77,7 @@ export function getUserInfo() {
         }
 
         if (response.status == 204 && history.location.pathname != '/registerComplete') {
-            history.push('/registerComplete')
+            history.push('/registerComplete', { profile: profile})
             return Promise.resolve();
         }
 
@@ -103,7 +103,7 @@ export function setUser(data) {
     };
 }
 
-function loginResponseHandler(call) {
+function loginResponseHandler(call, profile) {
     return async dispatch => {
         dispatch(getRequestInc());
         let response = await call();
@@ -112,14 +112,14 @@ function loginResponseHandler(call) {
             localStorage.clear();
             throw new SubmissionError(await buildValidationState(response));
         }
-        return setUserInfo(response, dispatch);
+        return setUserInfo(response, profile, dispatch);
     }
 }
 
-async function setUserInfo(response, dispatch) {
+async function setUserInfo(response, profile, dispatch) {
     let jsonRes = await response.json();
     localStorage.setItem(jwtStorageKey, jsonRes.token);
 
-    dispatch(getUserInfo());
+    dispatch(getUserInfo(profile));
     return Promise.resolve();
 }

--- a/EventsExpress/ClientApp/src/actions/register/register-bind-account-action.js
+++ b/EventsExpress/ClientApp/src/actions/register/register-bind-account-action.js
@@ -1,0 +1,25 @@
+﻿import { AuthenticationService } from '../../services';
+import { createBrowserHistory } from 'history';
+import { setSuccessAllert } from '../alert-action';
+import { buildValidationState } from '../../components/helpers/action-helpers';
+import { SubmissionError } from 'redux-form';
+import { jwtStorageKey } from '../../constants/constants';
+
+const api_serv = new AuthenticationService();
+const history = createBrowserHistory({ forceRefresh: true });
+
+export default function registerBindAccount(data) {
+    return async dispatch => {
+
+        let response = await api_serv.setRegisterBindAccount(data);
+        if (!response.ok) {
+            throw new SubmissionError(await buildValidationState(response));
+        }
+
+        let jsonRes = await response.json();
+        localStorage.setItem(jwtStorageKey, jsonRes.token);
+        dispatch(setSuccessAllert('Your profile was updated'));
+        dispatch(history.push('/home'))
+        return Promise.resolve();
+    };
+}

--- a/EventsExpress/ClientApp/src/components/register/register-bind-account.jsx
+++ b/EventsExpress/ClientApp/src/components/register/register-bind-account.jsx
@@ -25,35 +25,39 @@ class RegisterBindAccount extends Component {
     render() {
         const { pristine, submitting } = this.props;
         return (
-            <div className="register">
-                <h2>Already have an account?</h2>
-                <form onSubmit={this.props.handleSubmit}>
-                    <div>
-                        <Field
-                            name="email"
-                            component={renderTextField}
-                            label="E-mail:"
-                            type="email"
-                        />
-                    </div>
-                    <div>
-                        <Field
-                            name="password"
-                            component={renderTextField}
-                            label="Password:"
-                            type="password"
-                            validate={[maxLength15, minLength6]}
-                        />
-                    </div>
-                    <div>
-                        <DialogActions>
-                            <Button fullWidth={true} type="submit" color="primary" disabled={pristine || submitting}>
-                                Bind
-                            </Button>
-                        </DialogActions>
-                    </div>
-                </form>
-            </div>
+            <>
+                <div className="row">
+                    <h5 className="m-3">Already have an account?</h5>
+                </div>
+                <div className="row">
+                    <form onSubmit={this.props.handleSubmit} className="col-md-6">
+                        <div className="form-group">
+                            <Field
+                                name="email"
+                                component={renderTextField}
+                                label="E-mail:"
+                                type="email"
+                            />
+                        </div>
+                        <div className="form-group">
+                            <Field
+                                name="password"
+                                component={renderTextField}
+                                label="Password:"
+                                type="password"
+                                validate={[maxLength15, minLength6]}
+                            />
+                        </div>
+                        <div className="form-group">
+                            <DialogActions>
+                                <Button fullWidth={true} type="submit" color="primary" disabled={pristine || submitting}>
+                                    Bind
+                                </Button>
+                            </DialogActions>
+                        </div>
+                    </form>
+                </div>
+            </>
         );
     }
 }

--- a/EventsExpress/ClientApp/src/components/register/register-bind-account.jsx
+++ b/EventsExpress/ClientApp/src/components/register/register-bind-account.jsx
@@ -1,0 +1,75 @@
+﻿import React, { Component } from "react";
+import DialogActions from "@material-ui/core/DialogActions";
+import { Field, reduxForm, getFormValues } from "redux-form";
+import { connect } from 'react-redux';
+import Button from "@material-ui/core/Button";
+import { minLength6, maxLength15 } from '../helpers/validators/min-max-length-validators'
+import { renderSelectField, renderTextField } from '../helpers/form-helpers';
+import { isValidEmail } from '../helpers/validators/email-address-validator';
+import { fieldIsRequired } from '../helpers/validators/required-fields-validator';
+
+const validate = values => {
+    const requiredFields = [
+        'password',
+        'email',
+        'type'
+    ];
+
+    return {
+        ...fieldIsRequired(values, requiredFields),
+        ...isValidEmail(values.email)
+    }
+}
+
+class RegisterBindAccount extends Component {
+    render() {
+        const { pristine, submitting } = this.props;
+        return (
+            <div className="register">
+                <h2>Already have an account?</h2>
+                <form onSubmit={this.props.handleSubmit}>
+                    <div>
+                        <Field
+                            name="email"
+                            component={renderTextField}
+                            label="E-mail:"
+                            type="email"
+                        />
+                    </div>
+                    <div>
+                        <Field
+                            name="password"
+                            component={renderTextField}
+                            label="Password:"
+                            type="password"
+                            validate={[maxLength15, minLength6]}
+                        />
+                    </div>
+                    <div>
+                        <DialogActions>
+                            <Button fullWidth={true} type="submit" color="primary" disabled={pristine || submitting}>
+                                Bind
+                            </Button>
+                        </DialogActions>
+                    </div>
+                </form>
+            </div>
+        );
+    }
+}
+
+const mapStateToProps = (state) => {
+    const profile = state.routing.location.state.profile;
+    return {
+        initialValues: {
+            type: profile.type
+        },
+        form_values: getFormValues('register-bind-account-form')(state),
+    }
+}
+
+export default connect(mapStateToProps)(reduxForm({
+    form: "register-bind-account-form",
+    validate,
+    enableReinitialize: true
+})(RegisterBindAccount));

--- a/EventsExpress/ClientApp/src/components/register/register-bind-account.jsx
+++ b/EventsExpress/ClientApp/src/components/register/register-bind-account.jsx
@@ -4,7 +4,7 @@ import { Field, reduxForm, getFormValues } from "redux-form";
 import { connect } from 'react-redux';
 import Button from "@material-ui/core/Button";
 import { minLength6, maxLength15 } from '../helpers/validators/min-max-length-validators'
-import { renderSelectField, renderTextField } from '../helpers/form-helpers';
+import { renderTextField } from '../helpers/form-helpers';
 import { isValidEmail } from '../helpers/validators/email-address-validator';
 import { fieldIsRequired } from '../helpers/validators/required-fields-validator';
 

--- a/EventsExpress/ClientApp/src/components/register/register-complete.jsx
+++ b/EventsExpress/ClientApp/src/components/register/register-complete.jsx
@@ -35,7 +35,7 @@ const validate = values => {
 class RegisterComplete extends Component {
 
     render() {
-        const { pristine, submitting, handleSubmit, email, name } = this.props;
+        const { pristine, submitting, handleSubmit } = this.props;
         return (
             <>
                 <div className="row">

--- a/EventsExpress/ClientApp/src/components/register/register-complete.jsx
+++ b/EventsExpress/ClientApp/src/components/register/register-complete.jsx
@@ -1,5 +1,6 @@
 import React, {Component} from "react";
-import {Field, reduxForm} from "redux-form";
+import { Field, reduxForm, getFormValues } from "redux-form";
+import { connect } from 'react-redux';
 import Button from "@material-ui/core/Button";
 import { renderSelectField, renderPhoneInput, renderDatePicker, renderTextField} from '../helpers/form-helpers';
 import moment from "moment";
@@ -34,7 +35,7 @@ const validate = values => {
 class RegisterComplete extends Component {
 
     render() {
-        const {pristine, submitting, handleSubmit} = this.props;
+        const { pristine, submitting, handleSubmit, email, name } = this.props;
         return (
             <>
                 <div className="row">
@@ -43,7 +44,7 @@ class RegisterComplete extends Component {
                 <div className="row">
                     <form onSubmit={handleSubmit} className="col-md-6">
                         <div className="form-group">
-                            <Field
+                            < Field
                                 name="email"
                                 component={renderTextField}
                                 label="E-mail:"
@@ -51,7 +52,7 @@ class RegisterComplete extends Component {
                             />
                         </div>
                         <div className="form-group">
-                            <Field
+                            < Field
                                 name="userName"
                                 component={renderTextField}
                                 label="User name"
@@ -76,7 +77,7 @@ class RegisterComplete extends Component {
                                     label="Gender"
                                     parse={Number}
                                 >
-                                    <option aria-label="None" value={0}/>
+                                    <option aria-label="None" value={0} />
                                     <option value={1}>Male</option>
                                     <option value={2}>Female</option>
                                     <option value={3}>Other</option>
@@ -102,9 +103,23 @@ class RegisterComplete extends Component {
     }
 }
 
-RegisterComplete = reduxForm({
-    form: "register-complete-form",
-    validate
-})(RegisterComplete);
+const mapStateToProps = (state) => {
+    const profile = 'profile' in state.routing.location.state ? state.routing.location.state.profile : null;
+    if (profile)
+        return {
+            initialValues: {
+                email: 'email' in profile ? profile.email : null,
+                userName: 'name' in profile ? profile.name : null,
+                birthday: 'birthday' in profile ? profile.birthday: null,
+                gender: 'gender' in profile ? profile.gender : null
+            },
+            form_values: getFormValues('register-complete-form')(state),
+        }
+    else return
+}
 
-export default RegisterComplete;
+export default connect(mapStateToProps)(reduxForm({
+    form: "register-complete-form",
+    validate,
+    enableReinitialize: true
+})(RegisterComplete));

--- a/EventsExpress/ClientApp/src/components/register/register-complete.jsx
+++ b/EventsExpress/ClientApp/src/components/register/register-complete.jsx
@@ -18,6 +18,11 @@ const validate = values => {
         'gender'
     ]
 
+    if (values.userName.length < 3)
+        errors.userName = 'User name too short'
+    else if (values.userName.length > 50)
+        errors.userName = 'User name too long'
+
     if (values.phone && !isValidPhoneNumber(values.phone)) {
         errors.phone = 'Invalid phone number'
     }

--- a/EventsExpress/ClientApp/src/containers/FacebookLogin.js
+++ b/EventsExpress/ClientApp/src/containers/FacebookLogin.js
@@ -11,7 +11,7 @@ class LoginFacebook extends Component {
             if (typeof response.email === 'undefined') {
                 this.props.login.loginError = " Please add email to your facebook account!"
             }
-            this.props.loginFacebook(response.email, response.name, response.picture.data.url);
+            this.props.loginFacebook(response);
         }
 
         return (
@@ -40,7 +40,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
     return {
-        loginFacebook: (email, name, picture) => dispatch(loginFacebook(email, name, picture))
+        loginFacebook: (profile) => dispatch(loginFacebook(profile))
     }
 };
 

--- a/EventsExpress/ClientApp/src/containers/GoogleLogin.js
+++ b/EventsExpress/ClientApp/src/containers/GoogleLogin.js
@@ -14,9 +14,7 @@ class LoginGoogle extends Component {
 
         this.props.loginGoogle(
             response.tokenId,
-            response.profileObj.email,
-            response.profileObj.name,
-            response.profileObj.imageUrl
+            response.profileObj
         );
     }
 
@@ -37,7 +35,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
     return {
-        loginGoogle: (tokenId, email, name, imageUrl) => dispatch(loginGoogle(tokenId, email, name, imageUrl))
+        loginGoogle: (tokenId, profile) => dispatch(loginGoogle(tokenId, profile))
     }
 };
 

--- a/EventsExpress/ClientApp/src/containers/register-complete-wrapper.js
+++ b/EventsExpress/ClientApp/src/containers/register-complete-wrapper.js
@@ -1,5 +1,7 @@
 import React, {Component} from 'react';
-import {connect} from 'react-redux';
+import { connect } from 'react-redux';
+import RegisterBindAccount from "../components/register/register-bind-account";
+import registerBindAccount from "../actions/register/register-bind-account-action";
 import RegisterComplete from '../components/register/register-complete';
 import registerComplete from "../actions/register/register-complete-action";
 
@@ -11,7 +13,8 @@ class RegisterCompleteWrapper extends Component {
 
     render() {
         return <>
-            <RegisterComplete onSubmit={this.props.submit} profile={this.profile}/>
+            {typeof this.profile !== undefined && <RegisterBindAccount onSubmit={this.props.bind}/>}
+            <RegisterComplete onSubmit={this.props.submit}/>
         </>
     }
 }
@@ -19,6 +22,7 @@ class RegisterCompleteWrapper extends Component {
 const mapStateToProps = () => ({});
 
 const mapDispatchToProps = (dispatch) => ({
+    bind: (data) => dispatch(registerBindAccount(data)),
     submit: (data) => dispatch(registerComplete(data))
 });
 

--- a/EventsExpress/ClientApp/src/containers/register-complete-wrapper.js
+++ b/EventsExpress/ClientApp/src/containers/register-complete-wrapper.js
@@ -4,9 +4,14 @@ import RegisterComplete from '../components/register/register-complete';
 import registerComplete from "../actions/register/register-complete-action";
 
 class RegisterCompleteWrapper extends Component {
+    constructor(props) {
+        super(props);
+        this.profile = props.location.state.profile !== undefined ? this.props.location.state.profile : undefined
+    }
+
     render() {
         return <>
-            <RegisterComplete onSubmit={this.props.submit}/>
+            <RegisterComplete onSubmit={this.props.submit} profile={this.profile}/>
         </>
     }
 }

--- a/EventsExpress/ClientApp/src/services/AuthenticationService.js
+++ b/EventsExpress/ClientApp/src/services/AuthenticationService.js
@@ -24,6 +24,8 @@ export default class AuthenticationService {
 
     setRegister = data => baseService.setResource('Authentication/RegisterBegin', data);
 
+    setRegisterBindAccount = data => baseService.setResource('Authentication/RegisterBindExternalAccount', data);
+
     setRegisterComplete = data => baseService.setResource('Authentication/RegisterComplete', data)
 
     setChangePassword = data =>  baseService.setResource('Authentication/ChangePassword', data);

--- a/EventsExpress/Controllers/AuthenticationController.cs
+++ b/EventsExpress/Controllers/AuthenticationController.cs
@@ -140,6 +140,18 @@ namespace EventsExpress.Controllers
 
         [Authorize]
         [HttpPost("[action]")]
+        public async Task<IActionResult> RegisterBindExternalAccount(RegisterBindViewModel authRequest)
+        {
+            var accountData = _mapper.Map<RegisterBindDto>(authRequest);
+            var authResponseModel = await _authService.BindExternalAccount(accountData);
+
+            _tokenService.SetTokenCookie(authResponseModel.RefreshToken);
+
+            return Ok(new { Token = authResponseModel.JwtToken });
+        }
+
+        [Authorize]
+        [HttpPost("[action]")]
         public async Task<IActionResult> RegisterComplete(RegisterCompleteViewModel authRequest)
         {
             var profileData = _mapper.Map<RegisterCompleteDto>(authRequest);

--- a/EventsExpress/Controllers/AuthenticationController.cs
+++ b/EventsExpress/Controllers/AuthenticationController.cs
@@ -154,6 +154,11 @@ namespace EventsExpress.Controllers
         [HttpPost("[action]")]
         public async Task<IActionResult> RegisterComplete(RegisterCompleteViewModel authRequest)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
             var profileData = _mapper.Map<RegisterCompleteDto>(authRequest);
 
             await _authService.RegisterComplete(profileData);

--- a/EventsExpress/Mapping/RegisterMapperProfile.cs
+++ b/EventsExpress/Mapping/RegisterMapperProfile.cs
@@ -12,6 +12,7 @@ namespace EventsExpress.Mapping
         public RegisterMapperProfile()
         {
             CreateMap<LoginViewModel, RegisterDto>();
+            CreateMap<RegisterBindViewModel, RegisterBindDto>();
             CreateMap<RegisterCompleteViewModel, RegisterCompleteDto>();
 
             CreateMap<RegisterDto, Account>()

--- a/EventsExpress/Validation/RegisterCompleteViewModelValidator.cs
+++ b/EventsExpress/Validation/RegisterCompleteViewModelValidator.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using EventsExpress.ViewModels;
+using FluentValidation;
+
+namespace EventsExpress.Validation
+{
+    public class RegisterCompleteViewModelValidator : AbstractValidator<RegisterCompleteViewModel>
+    {
+        public RegisterCompleteViewModelValidator()
+        {
+            RuleFor(x => x.Birthday).NotEmpty().WithMessage("Birthday date is required");
+            RuleFor(x => x.Birthday).InclusiveBetween(DateTime.Now.AddYears(-115), DateTime.Now.AddYears(-15)).WithMessage("Birthday date is not correct");
+            RuleFor(x => x.Email).NotEmpty().WithMessage("Email address is required");
+            RuleFor(x => x.Email).EmailAddress().WithMessage("Email address is not correct");
+            RuleFor(x => x.Gender).NotEmpty().WithMessage("Gender is required");
+            RuleFor(x => x.Gender).IsInEnum().WithMessage("Gender is not correct");
+            RuleFor(x => x.Phone).NotEmpty().WithMessage("Phonenumber is required");
+            RuleFor(x => x.Phone).Must(Phonenumber).WithMessage("Phonenumber is not correct");
+            RuleFor(x => x.Username).NotEmpty().WithMessage("Username is required");
+            RuleFor(x => x.Username).MinimumLength(3).WithMessage("Username is too short");
+            RuleFor(x => x.Username).MaximumLength(50).WithMessage("Username is too long");
+        }
+
+        private bool Phonenumber(string phone)
+        {
+            phone = Regex.Replace(phone, @"\D", string.Empty);
+
+            return Regex.IsMatch(phone, @"\d{8,15}");
+        }
+    }
+}

--- a/EventsExpress/ViewModels/RegisterBindViewModel.cs
+++ b/EventsExpress/ViewModels/RegisterBindViewModel.cs
@@ -1,0 +1,13 @@
+﻿using EventsExpress.Db.Enums;
+
+namespace EventsExpress.ViewModels
+{
+    public class RegisterBindViewModel
+    {
+        public string Email { get; set; }
+
+        public string Password { get; set; }
+
+        public AuthExternalType Type { get; set; }
+    }
+}


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @iuriikhrystiuk

### Second Level Review

- [ ] @sand0

## Summary of issue

Lack of ability to select an existing account if the user already has one and pull-up user data when registering through external provider

## Summary of change

1) Added functionality for bind to local account into 'AuthenticationController' and 'AuthService'
2) Added 'RegisterBindDto' and 'RegisterBindViewModel'
3) Improved external login components, login actions and 'register complete form' for pass user info from external provider
4) Created and added into 'register complete wraper' 'register bind account' form

## Testing approach

ToDo

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
