### PR TITLE
Added redirection from landing to event filter

### DIFF
--- a/EventsExpress/ClientApp/src/components/landing/landing.js
+++ b/EventsExpress/ClientApp/src/components/landing/landing.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Carousel from 'react-material-ui-carousel';
+import { Link } from 'react-router-dom';
 import './landing.css';
 
 export default class Landing extends Component {
@@ -33,7 +34,7 @@ export default class Landing extends Component {
                         <h2>What do you want to do?</h2>
                         <div className="buttons">
                             <button className="btn btn-warning">Create event</button>
-                            <button className="btn btn-warning">Find event</button>
+                            <Link to={"home/events"} className="btn btn-warning">Find event</Link>
                         </div>
                     </div>
                 </article>


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @iuriikhrystiuk

### Second Level Review

- [ ] @sand0

## Summary of issue

User could not go from landing page to event filter

## Summary of change

Added redirection to event filter when user clicks on "Find event" button on landing page

## Testing approach

ToDo

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
