### PR TITLE
Fix by adding new policy that require admin or user role

### DIFF
--- a/EventsExpress/ClientApp/src/components/app/app.js
+++ b/EventsExpress/ClientApp/src/components/app/app.js
@@ -74,7 +74,7 @@ class App extends Component {
                                 <Route path="/event/:id/:page" component={EventItemViewWrapper} />
                                 <Route path="/eventSchedules" component={EventSchedulesListWrapper} />
                                 <Route path="/eventSchedule/:id" component={EventScheduleViewWrapper} />
-                                <Route path="/user/:id" component={this.UserRoleSecurity(UserItemViewWrapper)} />
+                                <Route path="/user/:id" component={this.AdminAndUserRoleSecurity(UserItemViewWrapper)} />
                                 <Route path="/admin" component={this.AdminRoleSecurity(Admin)} />
                                 <Route path="/search/users" component={this.UserRoleSecurity(SearchUserWrapper)} />
                                 <Route path="/user_chats" component={this.AdminAndUserRoleSecurity(UserChats)} />

--- a/EventsExpress/Controllers/UsersController.cs
+++ b/EventsExpress/Controllers/UsersController.cs
@@ -239,7 +239,7 @@ namespace EventsExpress.Controllers
         /// <response code="200">Return profileDto.</response>
         /// <response code="400">Attitude set failed.</response>
         [HttpGet("[action]")]
-        [Authorize(Policy = PolicyNames.UserPolicyName)]
+        [Authorize(Policy = PolicyNames.AdminAndUserPolicyName)]
         public IActionResult GetUserProfileById(Guid id)
         {
             var res = _mapper.Map<ProfileViewModel>(_userService.GetProfileById(id));

--- a/EventsExpress/Policies/PolicyNames.cs
+++ b/EventsExpress/Policies/PolicyNames.cs
@@ -6,6 +6,8 @@
 
         public const string UserPolicyName = "UserPolicy";
 
+        public const string AdminAndUserPolicyName = "AdminAndUserPolicy";
+
         public const string AdminRole = "Admin";
 
         public const string UserRole = "User";

--- a/EventsExpress/Startup.cs
+++ b/EventsExpress/Startup.cs
@@ -68,6 +68,8 @@ namespace EventsExpress
                         policy.Requirements.Add(new RoleRequirement(PolicyNames.AdminRole)));
                     options.AddPolicy(PolicyNames.UserPolicyName, policy =>
                         policy.Requirements.Add(new RoleRequirement(PolicyNames.UserRole)));
+                    options.AddPolicy(PolicyNames.AdminAndUserPolicyName, policy =>
+                        policy.RequireRole(PolicyNames.AdminRole, PolicyNames.UserRole));
                 })
                 .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddJwtBearer(options =>


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @uriikhrystiuk

### Second Level Review

- [ ] @sand0

## Summary of issue

403 Forbidden when admin go to user profile page

## Summary of change

Fix by adding new policy that require admin or user role

## Testing approach

1. Login as admin
2. Go to /home/events page
3. Click on user that created this event

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
