### PR TITLE
Add functionality to Join EventsExpress button on landing page

### DIFF
--- a/EventsExpress/ClientApp/src/components/header-profile/header-profile.js
+++ b/EventsExpress/ClientApp/src/components/header-profile/header-profile.js
@@ -4,6 +4,7 @@ import IconButton from "@material-ui/core/IconButton";
 import Badge from '@material-ui/core/Badge';
 import Tooltip from '@material-ui/core/Tooltip';
 import Zoom from '@material-ui/core/Zoom';
+import Button from "@material-ui/core/Button";
 import filterHelper from '../helpers/filterHelper';
 import ModalWind from '../modal-wind';
 import CustomAvatar from '../avatar/custom-avatar';

--- a/EventsExpress/ClientApp/src/components/header-profile/header-profile.js
+++ b/EventsExpress/ClientApp/src/components/header-profile/header-profile.js
@@ -26,9 +26,13 @@ export default class HeaderProfile extends Component {
         return (
             <div className='header-profile-root'>
                 <div className='d-inline-block'>
-                    {!id && (
-                        <ModalWind />
-                    )}
+                    {!id && (<ModalWind
+                                renderButton={(action) => (
+                                    <Button className='mt-5 btn btn-warning' variant="contained" onClick={action}>
+                                        Sign In/Up
+                                      </Button>
+                                )}/>)
+                    }
                     <AuthComponent>
                         <div className="d-flex flex-column align-items-center">
                             <CustomAvatar size="big" userId={id} name={this.props.user.name} />

--- a/EventsExpress/ClientApp/src/components/landing/landing.js
+++ b/EventsExpress/ClientApp/src/components/landing/landing.js
@@ -65,7 +65,7 @@ export default class Landing extends Component {
                                                 renderButton={(action) => (
                                                     <Button className='mt-5 btn btn-warning' variant="contained" onClick={action}>
                                                         Sign In/Up
-                                                      </Button>
+                                                    </Button>
                                                 )}/>)
                             }
                         </div>
@@ -110,9 +110,16 @@ export default class Landing extends Component {
                             <h3>Have Fun Together</h3>
                         </div>
                     </div>
-                    <div className="text-center">
-                        <button className="btn btn-warning">Join EventsExpress</button>
-                    </div>
+                    <AuthComponent onlyAnonymous>
+                        <div className="text-center">
+                            <ModalWind
+                                renderButton={(action) => (
+                                    <button className="btn btn-warning" onClick={() => action()}>
+                                        Join EventsExpress
+                                    </button>
+                                )}/>
+                        </div>
+                    </AuthComponent>
                 </article>
                 {events.length !== 0 &&
                 <article className="events-article">

--- a/EventsExpress/ClientApp/src/components/landing/landing.js
+++ b/EventsExpress/ClientApp/src/components/landing/landing.js
@@ -1,4 +1,5 @@
 ﻿import React, { Component } from 'react';
+import Button from "@material-ui/core/Button";
 import Carousel from 'react-material-ui-carousel';
 import CarouselEventCard from './CarouselEventCard';
 import EventService from '../../services/EventService';
@@ -59,8 +60,13 @@ export default class Landing extends Component {
                         </div>
                         <AuthComponent onlyAnonymous>
                             <div className="col-md-1">
-                            {
-                                !id && (<ModalWind />)
+                                {
+                                    !id && (<ModalWind
+                                                renderButton={(action) => (
+                                                    <Button className='mt-5 btn btn-warning' variant="contained" onClick={action}>
+                                                        Sign In/Up
+                                                      </Button>
+                                                )}/>)
                             }
                         </div>
                         </AuthComponent>

--- a/EventsExpress/ClientApp/src/components/modal-wind/modal-wind.js
+++ b/EventsExpress/ClientApp/src/components/modal-wind/modal-wind.js
@@ -47,9 +47,9 @@ function ModalWind(props) {
 
   return (
     <div className='d-inline-block'>
-          <Button className='mt-5 btn btn-warning' variant="contained" onClick={handleClickOpen}>
-        Sign In/Up
-      </Button>
+      {
+          props.renderButton(handleClickOpen)
+      }
       <Dialog
         open={props.status.isOpen}
         onClose={handleClose}


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @sand0

### Second Level Review

- [ ] @PirogStanislav

## Summary of issue

User has to be able to see login/register modal window by clicking on "Joing EventsExpress" button on landing page"

## Summary of change

Added functionality to "Join EventsExpress" button on landing page.

## Testing approach

1. Go to landing page as guest
2. Scroll down
3. Click "Join EventsExpress" button

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
