### PR TITLE
Fixed Facebook share button UI

### DIFF
--- a/EventsExpress/ClientApp/src/components/event/share/ShareButtons.js
+++ b/EventsExpress/ClientApp/src/components/event/share/ShareButtons.js
@@ -10,7 +10,7 @@ export class ShareButtons extends Component {
         return (
             <>
                 <FacebookProvider appId={this.props.config.facebookClientId}>
-                    <ShareButton className="btn" href={this.props.href} >
+                    <ShareButton className="btn btn-link" href={this.props.href} >
                         <div id="fb-share-button">
                             <i className="fab fa-facebook text-white" />
                         </div>

--- a/EventsExpress/ClientApp/src/components/event/share/share.css
+++ b/EventsExpress/ClientApp/src/components/event/share/share.css
@@ -9,7 +9,7 @@
     background: #3b5998;
     border-radius: 3px;
     font-weight: 600;
-    padding: 4px 10px;
+    padding: 8px 20px;
     display: inline-block;
     position: static;
 }


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @iuriikhrystiuk 

### Second Level Review

- [ ] @sand0 

## Summary of issue
On the home page, the Facebook share button design was smaller than other buttons

## Summary of change
Fixed button size & style


## CHECK LIST
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out the user if needed
- [x]  PR meets all conventions
