### PR TITLE
Added event filtering for registered & unregistered users

### DIFF
--- a/EventsExpress.Core/Services/EventService.cs
+++ b/EventsExpress.Core/Services/EventService.cs
@@ -421,6 +421,10 @@ namespace EventsExpress.Core.Services
                         categoryIds.Contains(category.CategoryId)));
             }
 
+            events = !_securityContextService.UserIsAuthentificated()
+                ? events.Where(x => x.IsPublic == true)
+                : events;
+
             count = events.Count();
 
             var result = events

--- a/EventsExpress.Core/Services/SecurityContextService.cs
+++ b/EventsExpress.Core/Services/SecurityContextService.cs
@@ -38,5 +38,24 @@ namespace EventsExpress.Core.Services
 
             return result;
         }
+
+        public bool UserIsAuthentificated()
+        {
+            Claim guidClaim = _httpContextAccessor.HttpContext.User.FindFirst(ClaimTypes.Name);
+
+            if (guidClaim == null || !Guid.TryParse(guidClaim.Value, out Guid result))
+            {
+                return false;
+            }
+
+            guidClaim = _httpContextAccessor.HttpContext.User.FindFirst(ClaimTypes.Sid);
+
+            if (guidClaim == null || !Guid.TryParse(guidClaim.Value, out Guid res))
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/EventsExpress.Db/Bridge/ISecurityContext.cs
+++ b/EventsExpress.Db/Bridge/ISecurityContext.cs
@@ -7,5 +7,7 @@ namespace EventsExpress.Db.Bridge
         Guid GetCurrentUserId();
 
         Guid GetCurrentAccountId();
+
+        bool UserIsAuthentificated();
     }
 }


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

User can see private & public events, even though it is not registered.

## Summary of change

Unregistered users can see only public events.
Registered users can see private & public events.

## Testing approach

ToDo

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
