### PR TITLE
#613 - User Request for Private Events

### DIFF
--- a/EventsExpress.Core/Services/EventService.cs
+++ b/EventsExpress.Core/Services/EventService.cs
@@ -87,10 +87,10 @@ namespace EventsExpress.Core.Services
                 .FirstOrDefault();
 
             userEvent.UserStatusEvent = status;
-            await _mediator.Publish(new ParticipationMessage(userEvent.UserId, userEvent.EventId, status));
 
             Context.UserEvent.Update(userEvent);
             await Context.SaveChangesAsync();
+            await _mediator.Publish(new ParticipationMessage(userEvent.UserId, userEvent.EventId, status));
         }
 
         public async Task DeleteUserFromEvent(Guid userId, Guid eventId)

--- a/EventsExpress/ClientApp/src/components/event/approved-users-action.js
+++ b/EventsExpress/ClientApp/src/components/event/approved-users-action.js
@@ -1,5 +1,6 @@
 ﻿import React from 'react';
 import SimpleModal from './simple-modal';
+import Button from "@material-ui/core/Button";
 import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from "@material-ui/core/IconButton";
 import { connect } from 'react-redux';

--- a/EventsExpress/ClientApp/src/components/event/pending-users-action.js
+++ b/EventsExpress/ClientApp/src/components/event/pending-users-action.js
@@ -27,20 +27,24 @@ const PendingUsersActions = (props) => {
 
     return (
         <>
-            <Button
-                variant="contained"
-                className={classes.success}
-                onClick={() => props.approveUser(user.id, props.eventId, true)}
-            >
-                Approve
-            </Button>
-            <Button
-                variant="contained"
-                className={classes.danger}
-                onClick={() => props.approveUser(user.id, props.eventId, false)}
-            >
-                Deny
-            </Button>
+            {(isMyEvent) &&
+                <>
+                    <Button
+                        variant="contained"
+                        className={classes.success}
+                        onClick={() => props.approveUser(user.id, props.eventId, true)}
+                    >
+                        Approve
+                    </Button>
+                    <Button
+                        variant="contained"
+                        className={classes.danger}
+                        onClick={() => props.approveUser(user.id, props.eventId, false)}
+                    >
+                            Deny
+                    </Button>
+                </>
+            }
         </>
     )
 }

--- a/EventsExpress/ClientApp/src/components/event/pending-users-action.js
+++ b/EventsExpress/ClientApp/src/components/event/pending-users-action.js
@@ -1,35 +1,46 @@
 ﻿import React from 'react';
 import Button from "@material-ui/core/Button";
-import IconButton from "@material-ui/core/IconButton";
-import DeleteIcon from '@material-ui/icons/Delete';
+import { makeStyles } from "@material-ui/styles";
 import { connect } from 'react-redux';
 import { promoteToOwner, approveUser } from '../../actions/event/event-item-view-action';
 
+const useStyles = makeStyles((theme) => ({
+    success: {
+        color: '#fff',
+        backgroundColor: '#4caf50',
+        '&:hover': {
+            backgroundColor: '#388e3c'
+        }
+    },
+    danger: {
+        color: '#fff',
+        backgroundColor: '#f44336',
+        '&:hover': {
+            backgroundColor: '#d32f2f'
+        }
+    }
+}));
+
 const PendingUsersActions = (props) => {
     const { user, isMyEvent } = props;
+    const classes = useStyles();
+
     return (
         <>
-            {(isMyEvent) &&
-                <div>
-                <IconButton aria-label="delete" onClick={() => props.promoteToOwner(user.id, props.eventId)}>
-                        <DeleteIcon />
-                    </IconButton>
-                </div>
-            }
             <Button
-                variant="outlined"
-                color="success"
+                variant="contained"
+                className={classes.success}
                 onClick={() => props.approveUser(user.id, props.eventId, true)}
             >
                 Approve
-                        </Button>
+            </Button>
             <Button
+                variant="contained"
+                className={classes.danger}
                 onClick={() => props.approveUser(user.id, props.eventId, false)}
-                variant="outlined"
-                color="danger"
             >
                 Deny
-        </Button>
+            </Button>
         </>
     )
 }


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @iuriikhrystiuk 

### Second Level Review

- [ ] @sand0 

## Summary of issue

Every private event owner has the possibility to approve or decline a participant. Two buttons to approve or deny users must be implemented in this task, also some styles should be provided for better usability. The approved user appears in the list of visitors and denied user appears in the list of denied users.

## Summary of change

- fixed internal error 500 in API (it was unable to approve or decline user request)
- added styles to buttons in Pending List (provided needed styles)
- deleted redundant Delete Icon from Pending User (this button used to promote users from Pending List, so this point was dangerous)
- fixed missing import in 'approved-list-action.js' (the page had been crashed because of this)

## Testing approach

ToDo

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
