### PR TITLE
Fixed:#862(SetSomeSwaggerSettings)

### DIFF
--- a/EventsExpress/Startup.cs
+++ b/EventsExpress/Startup.cs
@@ -17,6 +17,7 @@ using EventsExpress.Hubs;
 using EventsExpress.Mapping;
 using EventsExpress.NotificationHandlers;
 using EventsExpress.Policies;
+using EventsExpress.SwaggerSettings;
 using EventsExpress.Validation;
 using FluentValidation;
 using FluentValidation.AspNetCore;
@@ -222,6 +223,7 @@ namespace EventsExpress
                         },
                     });
 
+                c.DocumentFilter<ApplyDocumentExtension>();
                 var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.XML";
                 var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
 

--- a/EventsExpress/SwaggerSettings/ApplyDocumentExtension.cs
+++ b/EventsExpress/SwaggerSettings/ApplyDocumentExtension.cs
@@ -2,10 +2,12 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Reflection.Metadata;
     using Microsoft.OpenApi.Models;
     using Swashbuckle.AspNetCore.SwaggerGen;
 
+    [ExcludeFromCodeCoverage]
     public class ApplyDocumentExtension : IDocumentFilter
     {
         public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)

--- a/EventsExpress/SwaggerSettings/ApplyDocumentExtension.cs
+++ b/EventsExpress/SwaggerSettings/ApplyDocumentExtension.cs
@@ -1,0 +1,33 @@
+﻿namespace EventsExpress.SwaggerSettings
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection.Metadata;
+    using Microsoft.OpenApi.Models;
+    using Swashbuckle.AspNetCore.SwaggerGen;
+
+    public class ApplyDocumentExtension : IDocumentFilter
+    {
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            if (swaggerDoc != null)
+            {
+                foreach (var path in swaggerDoc.Paths)
+                {
+                    if (path.Key.StartsWith("/api/Category/Create") || path.Key.StartsWith("/api/Category/Edit"))
+                    {
+                        var referenceForSchema = path.Value.Operations[OperationType.Post].Parameters[0].Schema.Reference;
+                        var myOpenApiMediaType = new OpenApiMediaType { Schema = new OpenApiSchema { Reference = referenceForSchema } };
+                        var reqBodyContent = new Dictionary<string, OpenApiMediaType>();
+                        reqBodyContent.Add("application/json", myOpenApiMediaType);
+                        reqBodyContent.Add("text/json", myOpenApiMediaType);
+                        reqBodyContent.Add("application/*+json", myOpenApiMediaType);
+                        var myOpenReqBody = new OpenApiRequestBody { Content = reqBodyContent, Description = "Param defines CategoryView model" };
+                        path.Value.Operations[OperationType.Post].RequestBody = myOpenReqBody;
+                        path.Value.Operations[OperationType.Post].Parameters = null;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue
Create and Edit methods from CategoryController did not work, because those methods use Custom ModelBinder so when the request is sent from swagger, parameters are not located in body(how it is supposed to be) but in quety string.

## Summary of change
Was created an class which implements IDocumentFilter and set some additional settings to Swagger in order to take parameters from body but not from query string when Custom ModelBinder is used with Swagger.  So now the Create and Edit methods from CategoryController work correctly.

## Testing approach

ToDo

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
