### PR TITLE
fixedUpcomingEventsShowingForAdmin

### DIFF
--- a/EventsExpress.Test/ControllerTests/EventControllerTests.cs
+++ b/EventsExpress.Test/ControllerTests/EventControllerTests.cs
@@ -113,5 +113,14 @@ namespace EventsExpress.Test.ControllerTests
             var expected = eventController.AllDraft();
             Assert.IsInstanceOf<OkObjectResult>(expected);
         }
+
+        [Test]
+        public void GetUpcomingEvents_OkResult()
+        {
+            int x = 1;
+            service.Setup(e => e.GetAll(new EventFilterViewModel(), out x)).Returns(new List<EventDto>());
+            var expected = eventController.GetUpcomingEvents();
+            Assert.IsInstanceOf<OkObjectResult>(expected);
+        }
     }
 }

--- a/EventsExpress.Test/ControllerTests/EventControllerTests.cs
+++ b/EventsExpress.Test/ControllerTests/EventControllerTests.cs
@@ -122,5 +122,14 @@ namespace EventsExpress.Test.ControllerTests
             var expected = eventController.GetUpcomingEvents();
             Assert.IsInstanceOf<OkObjectResult>(expected);
         }
+
+        [Test]
+        public void AllEvents_OkResult()
+        {
+            int x = 1;
+            service.Setup(e => e.GetAll(new EventFilterViewModel(), out x)).Returns(new List<EventDto>());
+            var expected = eventController.All(new EventFilterViewModel());
+            Assert.IsInstanceOf<OkObjectResult>(expected);
+        }
     }
 }

--- a/EventsExpress.Test/ControllerTests/EventControllerTests.cs
+++ b/EventsExpress.Test/ControllerTests/EventControllerTests.cs
@@ -125,6 +125,15 @@ namespace EventsExpress.Test.ControllerTests
         }
 
         [Test]
+        public void GetUpcomingEvents_ReturnBadRequest()
+        {
+            int x = 1;
+            service.Setup(e => e.GetAll(new EventFilterViewModel(), out x)).Throws<ArgumentOutOfRangeException>();
+            var expected = eventController.GetUpcomingEvents();
+            Assert.IsInstanceOf<BadRequestResult>(expected);
+        }
+
+        [Test]
         public void AllEvents_OkResult()
         {
             int x = 1;

--- a/EventsExpress.Test/ControllerTests/EventControllerTests.cs
+++ b/EventsExpress.Test/ControllerTests/EventControllerTests.cs
@@ -116,20 +116,20 @@ namespace EventsExpress.Test.ControllerTests
         }
 
         [Test]
-        public void GetUpcomingEvents_OkResult()
+        public void Upcoming_OkResult()
         {
             int x = 1;
             service.Setup(e => e.GetAll(new EventFilterViewModel(), out x)).Returns(new List<EventDto>());
-            var expected = eventController.GetUpcomingEvents();
+            var expected = eventController.Upcoming();
             Assert.IsInstanceOf<OkObjectResult>(expected);
         }
 
         [Test]
-        public void GetUpcomingEvents_ReturnBadRequest()
+        public void Upcoming_ReturnBadRequest()
         {
             int count = 1;
             service.Setup(e => e.GetAll(It.IsAny<EventFilterViewModel>(), out count)).Throws<ArgumentOutOfRangeException>();
-            var expected = eventController.GetUpcomingEvents();
+            var expected = eventController.Upcoming();
             Assert.IsInstanceOf<BadRequestResult>(expected);
         }
 

--- a/EventsExpress.Test/ControllerTests/EventControllerTests.cs
+++ b/EventsExpress.Test/ControllerTests/EventControllerTests.cs
@@ -127,8 +127,8 @@ namespace EventsExpress.Test.ControllerTests
         [Test]
         public void GetUpcomingEvents_ReturnBadRequest()
         {
-            int x = 1;
-            service.Setup(e => e.GetAll(new EventFilterViewModel(), out x)).Throws<ArgumentOutOfRangeException>();
+            int count = 1;
+            service.Setup(e => e.GetAll(It.IsAny<EventFilterViewModel>(), out count)).Throws<ArgumentOutOfRangeException>();
             var expected = eventController.GetUpcomingEvents();
             Assert.IsInstanceOf<BadRequestResult>(expected);
         }

--- a/EventsExpress.Test/ControllerTests/EventControllerTests.cs
+++ b/EventsExpress.Test/ControllerTests/EventControllerTests.cs
@@ -36,6 +36,7 @@ namespace EventsExpress.Test.ControllerTests
         private Mock<IValidator<IFormFile>> mockValidator;
         private UserDto _userDto;
         private Guid _idUser = Guid.NewGuid();
+        private Guid _eventId = Guid.NewGuid();
         private string _userEmal = "user@gmail.com";
 
         public PhotoService PhotoService { get; set; }
@@ -135,8 +136,23 @@ namespace EventsExpress.Test.ControllerTests
         [Test]
         public void PastEvents_OkResult()
         {
-            service.Setup(e => e.PastEventsByUserId(_idUser, new PaginationViewModel() { PageSize = 3, Page = 1 }));
+            service.Setup(e => e.PastEventsByUserId(_idUser, new PaginationViewModel() { PageSize = 3, Page = 1 })).Returns(new List<EventDto>());
             var expected = eventController.PastEvents(_idUser);
+            Assert.IsInstanceOf<OkObjectResult>(expected);
+        }
+
+        [Test]
+        public void AddUserToEvent_OkResult()
+        {
+            var expected = eventController.AddUserToEvent(_eventId, _idUser);
+            Assert.IsInstanceOf<OkResult>(expected.Result);
+        }
+
+        [Test]
+        public void GetCurrentRate_OkResult()
+        {
+            service.Setup(e => e.Exists(_eventId)).Returns(true);
+            var expected = eventController.GetCurrentRate(_eventId);
             Assert.IsInstanceOf<OkObjectResult>(expected);
         }
     }

--- a/EventsExpress.Test/ControllerTests/EventControllerTests.cs
+++ b/EventsExpress.Test/ControllerTests/EventControllerTests.cs
@@ -131,5 +131,13 @@ namespace EventsExpress.Test.ControllerTests
             var expected = eventController.All(new EventFilterViewModel());
             Assert.IsInstanceOf<OkObjectResult>(expected);
         }
+
+        [Test]
+        public void PastEvents_OkResult()
+        {
+            service.Setup(e => e.PastEventsByUserId(_idUser, new PaginationViewModel() { PageSize = 3, Page = 1 }));
+            var expected = eventController.PastEvents(_idUser);
+            Assert.IsInstanceOf<OkObjectResult>(expected);
+        }
     }
 }

--- a/EventsExpress.Test/ControllerTests/EventControllerTests.cs
+++ b/EventsExpress.Test/ControllerTests/EventControllerTests.cs
@@ -155,5 +155,35 @@ namespace EventsExpress.Test.ControllerTests
             var expected = eventController.GetCurrentRate(_eventId);
             Assert.IsInstanceOf<OkObjectResult>(expected);
         }
+
+        [Test]
+        public void SetEventTempPhoto_OkResult()
+        {
+            var expected = eventController.SetEventTempPhoto(_eventId, new PhotoViewModel());
+            Assert.IsInstanceOf<OkResult>(expected.Result);
+        }
+
+        [Test]
+        public void CreateNextFromParentWithEdit_OkResult()
+        {
+            service.Setup(e => e.EditNextEvent(new EventDto())).Returns(Task.FromResult(Guid.NewGuid()));
+            var expected = eventController.CreateNextFromParentWithEdit(_eventId, new EventEditViewModel());
+            Assert.IsInstanceOf<OkObjectResult>(expected.Result);
+        }
+
+        [Test]
+        public void Edit_OkResult()
+        {
+            service.Setup(e => e.Edit(new EventDto())).Returns(Task.FromResult(Guid.NewGuid()));
+            var expected = eventController.Edit(_eventId, new EventEditViewModel());
+            Assert.IsInstanceOf<OkObjectResult>(expected.Result);
+        }
+
+        [Test]
+        public void VisitedEvents_OkResult()
+        {
+            var expected = eventController.VisitedEvents(_idUser, 1);
+            Assert.IsInstanceOf<OkObjectResult>(expected);
+        }
     }
 }

--- a/EventsExpress.Test/EventsExpress.Test.csproj
+++ b/EventsExpress.Test/EventsExpress.Test.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.9" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="nunit" Version="3.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,6 +38,13 @@
     <None Update="ServiceTests\Images\valid-image.jpg">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.354">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/EventsExpress.Test/ServiceTests/UsersServiceTests.cs
+++ b/EventsExpress.Test/ServiceTests/UsersServiceTests.cs
@@ -178,7 +178,7 @@ namespace EventsExpress.Test.ServiceTests
             {
                 AccountStatus.Activated => await Context.Users.CountAsync(u => !u.Account.IsBlocked),
                 AccountStatus.Blocked => await Context.Users.CountAsync(u => u.Account.IsBlocked),
-                _ => await Context.Users.CountAsync()
+                _ => await Context.Users.CountAsync(),
             };
 
             // Act

--- a/EventsExpress/ClientApp/src/actions/event/event-list-action.js
+++ b/EventsExpress/ClientApp/src/actions/event/event-list-action.js
@@ -58,3 +58,18 @@ export function updateEventsFilters(data) {
         payload: data
     }
 }
+
+export function get_upcoming_events(filters) {
+    return async dispatch => {
+        dispatch(getRequestInc());
+        let response = await api_serv.getUpcomingEvents();
+        dispatch(getRequestDec());
+        if (!response.ok) {
+            dispatch(setErrorAllertFromResponse(response));
+            return Promise.reject();
+        }
+        let jsonRes = await response.json();
+        dispatch(getEvents(jsonRes));
+        return Promise.resolve();
+    }
+}

--- a/EventsExpress/ClientApp/src/components/landing/landing.js
+++ b/EventsExpress/ClientApp/src/components/landing/landing.js
@@ -32,7 +32,7 @@ export default class Landing extends Component {
     }
 
     async componentDidMount() {
-        let events = await eventService.getAllEvents("?Page=1")
+        let events = await eventService.getUpcomingEvents("?Page=1")
         events = (await events.json()).items
         if (events.length !== 0) {
             this.setState({ events: this.splitDataIntoBlocks(events) })

--- a/EventsExpress/ClientApp/src/components/landing/landing.js
+++ b/EventsExpress/ClientApp/src/components/landing/landing.js
@@ -7,7 +7,6 @@ import { Link } from "react-router-dom"
 import ModalWind from '../modal-wind';
 import AuthComponent from '../../security/authComponent';
 import './landing.css';
-import { withRouter } from "react-router";
 import { get_upcoming_events } from '../../actions/event/event-list-action';
 import { connect } from 'react-redux';
 const eventService = new EventService()
@@ -167,7 +166,7 @@ const mapDispatchToProps = (dispatch) => {
     }
 };
 
-export default withRouter(connect(
+export default(connect(
     mapStateToProps,
     mapDispatchToProps
 )(Landing));

--- a/EventsExpress/ClientApp/src/components/landing/landing.js
+++ b/EventsExpress/ClientApp/src/components/landing/landing.js
@@ -7,16 +7,14 @@ import { Link } from "react-router-dom"
 import ModalWind from '../modal-wind';
 import AuthComponent from '../../security/authComponent';
 import './landing.css';
-
+import { withRouter } from "react-router";
+import { get_upcoming_events } from '../../actions/event/event-list-action';
+import { connect } from 'react-redux';
 const eventService = new EventService()
 
-export default class Landing extends Component {
+class Landing extends Component {
     constructor(props) {
         super(props)
-
-        this.state = {
-            events: []
-                }
     }
 
     handleClick = () => {
@@ -31,12 +29,8 @@ export default class Landing extends Component {
         }, [])
     }
 
-    async componentDidMount() {
-        let events = await eventService.getUpcomingEvents()
-        events = (await events.json()).items
-        if (events.length !== 0) {
-            this.setState({ events: this.splitDataIntoBlocks(events) })
-        }
+    componentDidMount() {
+        this.props.get_upcoming_events();
     }
 
     renderCarouselBlock = (eventBlock) => (
@@ -44,13 +38,18 @@ export default class Landing extends Component {
             {eventBlock.map((event) => <CarouselEventCard key={event.id} event={event} />)}
         </div>
     )
-        
+
     render() {
-        const { events } = this.state
+        let { id } = this.props.user.id !== null
+            ? this.props.user
+            : {};
+        console.log(id);
+        const { items } = this.props.events.data;
+        const events = this.splitDataIntoBlocks(items);
+
         const carouselNavIsVisible = events.length > 1
         const { onLogoutClick } = this.props;
-        const { id } = this.props.user;
-      
+
         return (<>
             <div className="main">
                 <article className="head-article">
@@ -62,13 +61,13 @@ export default class Landing extends Component {
                             <div className="col-md-1">
                                 {
                                     !id && (<ModalWind
-                                                renderButton={(action) => (
-                                                    <Button className='mt-5 btn btn-warning' variant="contained" onClick={action}>
-                                                        Sign In/Up
-                                                    </Button>
-                                                )}/>)
-                            }
-                        </div>
+                                        renderButton={(action) => (
+                                            <Button className='mt-5 btn btn-warning' variant="contained" onClick={action}>
+                                                Sign In/Up
+                                            </Button>
+                                        )}/>)
+                                }
+                            </div>
                         </AuthComponent>
                         <AuthComponent>
                             <div className="col-md-2 text-right">
@@ -122,35 +121,53 @@ export default class Landing extends Component {
                     </AuthComponent>
                 </article>
                 {events.length !== 0 &&
-                <article className="events-article">
-                    <div className="row">
-                        <div className="col-md-10">
-                            <h3>Upcoming events</h3>
+                    <article className="events-article">
+                        <div className="row">
+                            <div className="col-md-10">
+                                <h3>Upcoming events</h3>
+                            </div>
+                            <div style={{ textAlign: 'right' }} className="col-md-2">
+                                <a href="/home/events">Explore more events</a>
+                            </div>
                         </div>
-                        <div style={{ textAlign: 'right' }} className="col-md-2">
-                            <a href="/home/events">Explore more events</a>
-                        </div>
-                    </div>
-                    <div className="carousel-wrapper text-center">
-                        <Carousel
-                            autoPlay={false}
-                            animation={"slide"}
-                            interval={1000}
-                            indicators={false}
+                        <div className="carousel-wrapper text-center">
+                            <Carousel
+                                autoPlay={false}
+                                animation={"slide"}
+                                interval={1000}
+                                indicators={false}
                                 navButtonsAlwaysVisible={carouselNavIsVisible}
                                 navButtonsAlwaysInvisible={!carouselNavIsVisible}
 
-                            NextIcon={<i style={{ width: 32 + 'px', height: 32 + 'px' }} className="fas fa-angle-right"></i>}
-                            PrevIcon={<i style={{ width: 32 + 'px', height: 32 + 'px' }} className="fas fa-angle-left"></i>}
-                        >
-                            {
+                                NextIcon={<i style={{ width: 32 + 'px', height: 32 + 'px' }} className="fas fa-angle-right"></i>}
+                                PrevIcon={<i style={{ width: 32 + 'px', height: 32 + 'px' }} className="fas fa-angle-left"></i>}
+                            >
+                                {
                                     events.map((block) => this.renderCarouselBlock(block))
-                            }
-                        </Carousel>
-                    </div>
-                </article>
+                                }
+                            </Carousel>
+                        </div>
+                    </article>
                 }
             </div>
         </>);
     }
 }
+
+const mapStateToProps = (state) => {
+    return {
+        events: state.events,
+        user: state.user,
+    }
+};
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        get_upcoming_events: () => dispatch(get_upcoming_events()),
+    }
+};
+
+export default withRouter(connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(Landing));

--- a/EventsExpress/ClientApp/src/components/landing/landing.js
+++ b/EventsExpress/ClientApp/src/components/landing/landing.js
@@ -32,7 +32,7 @@ export default class Landing extends Component {
     }
 
     async componentDidMount() {
-        let events = await eventService.getUpcomingEvents("?Page=1")
+        let events = await eventService.getUpcomingEvents()
         events = (await events.json()).items
         if (events.length !== 0) {
             this.setState({ events: this.splitDataIntoBlocks(events) })

--- a/EventsExpress/ClientApp/src/services/EventService.js
+++ b/EventsExpress/ClientApp/src/services/EventService.js
@@ -8,6 +8,8 @@ export default class EventService {
 
     getAllEvents = filters => baseService.getResource(`event/all${filters}`);
 
+    getUpcomingEvents = filtres => baseService.getResource(`event/GetUpcomingEvents${filtres}`)
+
     getAllDrafts = (page) => baseService.getResource(`event/AllDraft/${page}`);
           
     getEvents = (eventIds, page) => baseService.setResource(`event/getEvents?page=${page}`, eventIds);

--- a/EventsExpress/ClientApp/src/services/EventService.js
+++ b/EventsExpress/ClientApp/src/services/EventService.js
@@ -8,7 +8,7 @@ export default class EventService {
 
     getAllEvents = filters => baseService.getResource(`event/all${filters}`);
 
-    getUpcomingEvents = filtres => baseService.getResource(`event/GetUpcomingEvents${filtres}`)
+    getUpcomingEvents = () => baseService.getResource(`event/GetUpcomingEvents`)
 
     getAllDrafts = (page) => baseService.getResource(`event/AllDraft/${page}`);
           

--- a/EventsExpress/ClientApp/src/services/EventService.js
+++ b/EventsExpress/ClientApp/src/services/EventService.js
@@ -8,7 +8,7 @@ export default class EventService {
 
     getAllEvents = filters => baseService.getResource(`event/all${filters}`);
 
-    getUpcomingEvents = () => baseService.getResource(`event/GetUpcomingEvents`)
+    getUpcomingEvents = () => baseService.getResource(`event/Upcoming`)
 
     getAllDrafts = (page) => baseService.getResource(`event/AllDraft/${page}`);
           

--- a/EventsExpress/Controllers/EventController.cs
+++ b/EventsExpress/Controllers/EventController.cs
@@ -175,14 +175,14 @@ namespace EventsExpress.Controllers
         /// <summary>
         /// This method have to return upcoming events.
         /// </summary>
-        /// <param name="filter">Param filter provides the ability to filter the list of events.</param>
         /// <returns>The method returns filtered events.</returns>
         /// <response code="200">Return IEnumerable EventPreviewDto.</response>
         /// <response code="400">If return failed.</response>
         [AllowAnonymous]
         [HttpGet("[action]")]
-        public IActionResult GetUpcomingEvents([FromQuery] EventFilterViewModel filter)
+        public IActionResult GetUpcomingEvents()
         {
+            var filter = new EventFilterViewModel();
             filter.OwnerId = null;
             filter.VisitorId = null;
             filter.DateFrom = DateTime.Today;

--- a/EventsExpress/Controllers/EventController.cs
+++ b/EventsExpress/Controllers/EventController.cs
@@ -183,6 +183,7 @@ namespace EventsExpress.Controllers
         public IActionResult Upcoming()
         {
             var filter = new EventFilterViewModel();
+            filter.PageSize = 5;
             filter.DateFrom = DateTime.Today;
 
             try

--- a/EventsExpress/Controllers/EventController.cs
+++ b/EventsExpress/Controllers/EventController.cs
@@ -173,6 +173,37 @@ namespace EventsExpress.Controllers
         }
 
         /// <summary>
+        /// This method have to return upcoming events.
+        /// </summary>
+        /// <param name="filter">Param filter provides the ability to filter the list of events.</param>
+        /// <returns>The method returns filtered events.</returns>
+        /// <response code="200">Return IEnumerable EventPreviewDto.</response>
+        /// <response code="400">If return failed.</response>
+        [AllowAnonymous]
+        [HttpGet("[action]")]
+        public IActionResult GetUpcomingEvents([FromQuery] EventFilterViewModel filter)
+        {
+            filter.OwnerId = null;
+            filter.VisitorId = null;
+            filter.DateFrom = DateTime.Today;
+
+            try
+            {
+                var viewModel = new IndexViewModel<EventPreviewViewModel>
+                {
+                    Items = _mapper.Map<IEnumerable<EventPreviewViewModel>>(
+                        _eventService.GetAll(filter, out int count)),
+                    PageViewModel = new PageViewModel(count, filter.Page, filter.PageSize),
+                };
+                return Ok(viewModel);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return BadRequest();
+            }
+        }
+
+        /// <summary>
         /// This method have to return all events.
         /// </summary>
         /// <returns>The method returns filltered events.</returns>

--- a/EventsExpress/Controllers/EventController.cs
+++ b/EventsExpress/Controllers/EventController.cs
@@ -180,11 +180,9 @@ namespace EventsExpress.Controllers
         /// <response code="400">If return failed.</response>
         [AllowAnonymous]
         [HttpGet("[action]")]
-        public IActionResult GetUpcomingEvents()
+        public IActionResult Upcoming()
         {
             var filter = new EventFilterViewModel();
-            filter.OwnerId = null;
-            filter.VisitorId = null;
             filter.DateFrom = DateTime.Today;
 
             try


### PR DESCRIPTION
dev
## GitHub Project

#885

## Code reviewers

- [ ] @iuriikhrystiuk 
- [ ] @sand0 
### Second Level Review

- [ ] @YourFriendlyNeighbourPasha 

## Summary of issue

In section [Upcoming Events] on landing page, for admin ware displayed events that are not upcoming(old events which were completed), Also upcoming events were not displayed for unregistered users, now they are displayed.

## Summary of change

Was added a method GetUpcomingEvents in EventController which returns only upcoming events. Also was implemented redux flow on Landing component.

## Testing approach

ToDo

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
