### PR TITLE
#897 - Error on new event creation attempt, #903 - UI app does not handle 500 internal error correctly

### DIFF
--- a/EventsExpress.Test/FilterTests/EventsExpressExceptionFilterTests.cs
+++ b/EventsExpress.Test/FilterTests/EventsExpressExceptionFilterTests.cs
@@ -40,7 +40,7 @@ namespace EventsExpress.Test.FilterTests
 
             filter.OnException(exceptionContext);
             Assert.IsInstanceOf<ObjectResult>(exceptionContext.Result);
-            var result = (ObjectResult) exceptionContext.Result;
+            var result = (ObjectResult)exceptionContext.Result;
             var actual = result.StatusCode;
 
             Assert.AreEqual(expected, actual);
@@ -68,7 +68,7 @@ namespace EventsExpress.Test.FilterTests
 
             filter.OnException(exceptionContext);
             Assert.IsInstanceOf<ObjectResult>(exceptionContext.Result);
-            var result = (ObjectResult) exceptionContext.Result;
+            var result = (ObjectResult)exceptionContext.Result;
             var actual = JsonConvert.SerializeObject(result.Value);
 
             Assert.AreEqual(expected, actual);
@@ -86,7 +86,7 @@ namespace EventsExpress.Test.FilterTests
 
             filter.OnException(exceptionContext);
             Assert.IsInstanceOf<ObjectResult>(exceptionContext.Result);
-            var result = (ObjectResult) exceptionContext.Result;
+            var result = (ObjectResult)exceptionContext.Result;
             var actual = result.StatusCode;
 
             Assert.AreEqual(expected, actual);
@@ -110,7 +110,7 @@ namespace EventsExpress.Test.FilterTests
 
             filter.OnException(exceptionContext);
             Assert.IsInstanceOf<ObjectResult>(exceptionContext.Result);
-            var result = (ObjectResult) exceptionContext.Result;
+            var result = (ObjectResult)exceptionContext.Result;
             var actual = JsonConvert.SerializeObject(result.Value);
 
             Assert.AreEqual(expected, actual);

--- a/EventsExpress.Test/FilterTests/EventsExpressExceptionFilterTests.cs
+++ b/EventsExpress.Test/FilterTests/EventsExpressExceptionFilterTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using EventsExpress.Core.Exceptions;
+using EventsExpress.Filters;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace EventsExpress.Test.FilterTests
+{
+    [TestFixture]
+    internal class EventsExpressExceptionFilterTests
+    {
+        private ActionContext _actionContext;
+
+        [SetUp]
+        public void Initialize()
+        {
+            _actionContext = new ActionContext
+            {
+                HttpContext = new DefaultHttpContext(),
+                RouteData = new RouteData(),
+                ActionDescriptor = new ActionDescriptor(),
+            };
+        }
+
+        [Test]
+        public void OnException_WhenExpressExceptionThrown_StatusCodeShouldBe400()
+        {
+            var filter = new EventsExpressExceptionFilterAttribute();
+            var exceptionContext = new ExceptionContext(_actionContext, new List<IFilterMetadata>())
+            {
+                Exception = new EventsExpressException(),
+            };
+            const int expected = StatusCodes.Status400BadRequest;
+
+            filter.OnException(exceptionContext);
+            var result = exceptionContext.Result as ObjectResult;
+            var actual = result?.StatusCode;
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void OnException_WhenExpressExceptionThrown_ResultObjectShouldHaveErrors()
+        {
+            const string message = "Validation error occurred";
+            var filter = new EventsExpressExceptionFilterAttribute();
+            var validationErrors = new Dictionary<string, string>
+            {
+                { "Field", "Validation error" },
+            };
+            var expectedErrors = new Dictionary<string, Array>
+            {
+                { "_error", new[] { message } },
+                { "Field", new[] { "Validation error" } },
+            };
+            var exceptionContext = new ExceptionContext(_actionContext, new List<IFilterMetadata>())
+            {
+                Exception = new EventsExpressException(message, validationErrors),
+            };
+            var expected = JsonConvert.SerializeObject(new { Errors = expectedErrors });
+
+            filter.OnException(exceptionContext);
+            var result = exceptionContext.Result as ObjectResult;
+            var actual = JsonConvert.SerializeObject(result?.Value);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void OnException_WhenExceptionThrown_StatusCodeShouldBe500()
+        {
+            var filter = new EventsExpressExceptionFilterAttribute();
+            var exceptionContext = new ExceptionContext(_actionContext, new List<IFilterMetadata>())
+            {
+                Exception = new Exception(),
+            };
+            const int expected = StatusCodes.Status500InternalServerError;
+
+            filter.OnException(exceptionContext);
+            var result = exceptionContext.Result as ObjectResult;
+            var actual = result?.StatusCode;
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void OnException_WhenExceptionThrown_ResultObjectShouldHaveErrorWithMessage()
+        {
+            var filter = new EventsExpressExceptionFilterAttribute();
+            var exceptionContext = new ExceptionContext(_actionContext, new List<IFilterMetadata>())
+            {
+                Exception = new Exception(),
+            };
+            const string message = "Unhandled exception occurred. Please try again. "
+                                    + "If this error persists - contact system administrator.";
+            var expectedErrors = new Dictionary<string, Array>
+            {
+                { "_error", new[] { message } },
+            };
+            var expected = JsonConvert.SerializeObject(new { Errors = expectedErrors });
+
+            filter.OnException(exceptionContext);
+            var result = exceptionContext.Result as ObjectResult;
+            var actual = JsonConvert.SerializeObject(result?.Value);
+
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/EventsExpress.Test/FilterTests/EventsExpressExceptionFilterTests.cs
+++ b/EventsExpress.Test/FilterTests/EventsExpressExceptionFilterTests.cs
@@ -39,8 +39,9 @@ namespace EventsExpress.Test.FilterTests
             const int expected = StatusCodes.Status400BadRequest;
 
             filter.OnException(exceptionContext);
-            var result = exceptionContext.Result as ObjectResult;
-            var actual = result?.StatusCode;
+            Assert.IsInstanceOf<ObjectResult>(exceptionContext.Result);
+            var result = (ObjectResult) exceptionContext.Result;
+            var actual = result.StatusCode;
 
             Assert.AreEqual(expected, actual);
         }
@@ -66,8 +67,9 @@ namespace EventsExpress.Test.FilterTests
             var expected = JsonConvert.SerializeObject(new { Errors = expectedErrors });
 
             filter.OnException(exceptionContext);
-            var result = exceptionContext.Result as ObjectResult;
-            var actual = JsonConvert.SerializeObject(result?.Value);
+            Assert.IsInstanceOf<ObjectResult>(exceptionContext.Result);
+            var result = (ObjectResult) exceptionContext.Result;
+            var actual = JsonConvert.SerializeObject(result.Value);
 
             Assert.AreEqual(expected, actual);
         }
@@ -83,8 +85,9 @@ namespace EventsExpress.Test.FilterTests
             const int expected = StatusCodes.Status500InternalServerError;
 
             filter.OnException(exceptionContext);
-            var result = exceptionContext.Result as ObjectResult;
-            var actual = result?.StatusCode;
+            Assert.IsInstanceOf<ObjectResult>(exceptionContext.Result);
+            var result = (ObjectResult) exceptionContext.Result;
+            var actual = result.StatusCode;
 
             Assert.AreEqual(expected, actual);
         }
@@ -106,8 +109,9 @@ namespace EventsExpress.Test.FilterTests
             var expected = JsonConvert.SerializeObject(new { Errors = expectedErrors });
 
             filter.OnException(exceptionContext);
-            var result = exceptionContext.Result as ObjectResult;
-            var actual = JsonConvert.SerializeObject(result?.Value);
+            Assert.IsInstanceOf<ObjectResult>(exceptionContext.Result);
+            var result = (ObjectResult) exceptionContext.Result;
+            var actual = JsonConvert.SerializeObject(result.Value);
 
             Assert.AreEqual(expected, actual);
         }

--- a/EventsExpress/ClientApp/src/actions/event/event-add-action.js
+++ b/EventsExpress/ClientApp/src/actions/event/event-add-action.js
@@ -31,9 +31,9 @@ export function edit_event(data, onError, onSuccess) {
         dispatch(getRequestInc());
         let response = await api_serv.editEvent(data);
         dispatch(getRequestDec());
-        if (!response.ok && onError && typeof onError === 'function') {
+        if (!response.ok && onError) {
             await onError(response);
-        } else if (onSuccess && typeof onSuccess === 'function') {
+        } else if (response.ok && onSuccess) {
             onSuccess(response);
         }
         dispatch(getEvent(data));

--- a/EventsExpress/ClientApp/src/actions/event/event-add-action.js
+++ b/EventsExpress/ClientApp/src/actions/event/event-add-action.js
@@ -26,13 +26,15 @@ export default function add_event() {
     }
 }
 
-export function edit_event(data) {
+export function edit_event(data, onError, onSuccess) {
     return async dispatch => {
         dispatch(getRequestInc());
         let response = await api_serv.editEvent(data);
         dispatch(getRequestDec());
-        if (!response.ok) {
-            throw new SubmissionError(await buildValidationState(response));
+        if (!response.ok && onError && typeof onError === 'function') {
+            await onError(response);
+        } else if (onSuccess && typeof onSuccess === 'function') {
+            onSuccess(response);
         }
         dispatch(getEvent(data));
         return Promise.resolve();

--- a/EventsExpress/ClientApp/src/actions/event/event-add-action.js
+++ b/EventsExpress/ClientApp/src/actions/event/event-add-action.js
@@ -30,11 +30,11 @@ export function edit_event(data) {
     return async dispatch => {
         dispatch(getRequestInc());
         let response = await api_serv.editEvent(data);
+        dispatch(getRequestDec());
         if (!response.ok) {
             throw new SubmissionError(await buildValidationState(response));
         }
         dispatch(getEvent(data));
-        dispatch(getRequestDec());
         return Promise.resolve();
     }
 }

--- a/EventsExpress/ClientApp/src/components/event/event-form.js
+++ b/EventsExpress/ClientApp/src/components/event/event-form.js
@@ -62,6 +62,10 @@ class EventForm extends Component {
     const { form_values, all_categories, user_name } = this.props;
     const { checked } = this.state;
 
+    if (this.props.error) {
+      this.props.onError(this.props.error);
+    }
+
     return (
       <form
         onSubmit={this.props.handleSubmit(this.props.onSubmit)}

--- a/EventsExpress/ClientApp/src/components/helpers/action-helpers.js
+++ b/EventsExpress/ClientApp/src/components/helpers/action-helpers.js
@@ -1,24 +1,18 @@
 import 'react-widgets/dist/css/react-widgets.css';
 import 'react-datepicker/dist/react-datepicker.css';
 
-export const buildValidationState = async (responseData) => {
-    let result = {};
-    let jsonRes = await responseData.json();
+export const buildValidationState = async responseData => (await responseData.json()).errors;
 
-    for (const [key, value] of Object.entries(jsonRes.errors)) {
-        result = { ...result, [key]: value };
+export const getErrorMessage = async responseData => {
+    const entries = Object.entries(await buildValidationState(responseData));
+    if (entries.length === 0) {
+        return 'Something went wrong.';
     }
-    return result;
-};
 
-export const getErrorMessage = async (responseData) => {
-    let jsonRes = await responseData.json();
-
-    for (const [key, value] of Object.entries(jsonRes.errors)) {
-        if (key === '0') {
-            return `Error : ${value['errorMessage']}`;
-        }
-        return `Error for ${key}: ${value['errorMessage']}`;
+    const [key, value] = entries[0];
+    if (key === '_error') {
+        return `Error : ${value[0]}`;
     }
-    return 'Something went wrong.';
+
+    return `Error for ${key}: ${value[0]}`;
 };

--- a/EventsExpress/ClientApp/src/components/helpers/action-helpers.js
+++ b/EventsExpress/ClientApp/src/components/helpers/action-helpers.js
@@ -1,29 +1,24 @@
 import 'react-widgets/dist/css/react-widgets.css';
-import "react-datepicker/dist/react-datepicker.css";
+import 'react-datepicker/dist/react-datepicker.css';
 
 export const buildValidationState = async (responseData) => {
     let result = {};
     let jsonRes = await responseData.json();
 
     for (const [key, value] of Object.entries(jsonRes.errors)) {
-        if (key == "") {
-            result = { ...result, _error: value };
-        }
-        else {
-            result = { ...result, [key]: value };
-        }
+        result = { ...result, [key]: value };
     }
     return result;
-}
+};
 
 export const getErrorMessage = async (responseData) => {
     let jsonRes = await responseData.json();
 
-    for (const [key, value] of Object.entries(jsonRes[""].errors)) {
-        if (key === "0") {
-            return `Error : ${value["errorMessage"]}`;
+    for (const [key, value] of Object.entries(jsonRes.errors)) {
+        if (key === '0') {
+            return `Error : ${value['errorMessage']}`;
         }
-        return `Error for ${key}: ${value["errorMessage"]}`;
+        return `Error for ${key}: ${value['errorMessage']}`;
     }
-    return "Something went wrong.";
-}
+    return 'Something went wrong.';
+};

--- a/EventsExpress/ClientApp/src/containers/edit-event.js
+++ b/EventsExpress/ClientApp/src/containers/edit-event.js
@@ -1,21 +1,28 @@
 ﻿import React, { Component } from 'react';
 import EventForm from '../components/event/event-form';
-import { withRouter } from "react-router";
+import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
-import { getFormValues } from 'redux-form';
+import { getFormValues, SubmissionError } from 'redux-form';
 import { edit_event } from '../actions/event/event-add-action';
 import { setSuccessAllert } from '../actions/alert-action';
-import { validate } from './event-edit-validate-form '
-import { validateEventForm } from './event-validate-form'
-import Button from "@material-ui/core/Button";
+import { validate } from './event-edit-validate-form ';
+import { validateEventForm } from './event-validate-form';
+import Button from '@material-ui/core/Button';
+import { buildValidationState } from '../components/helpers/action-helpers';
 
 class EditEventWrapper extends Component {
 
     onSubmit = async (values) => {
-        await this.props.edit_event({ ...validateEventForm(values), user_id: this.props.user_id, id: this.props.event.id });
-        this.props.alert('Your event has been successfully saved!');    
+        await this.props.edit_event({
+            ...validateEventForm(values),
+            user_id: this.props.user_id,
+            id: this.props.event.id
+        }, async response => {
+            throw new SubmissionError(await buildValidationState(response));
+        });
+        this.props.alert('Your event has been successfully saved!');
         this.props.history.goBack();
-    }
+    };
 
     render() {
         return <>
@@ -48,7 +55,7 @@ class EditEventWrapper extends Component {
                     </div>
                 </EventForm>
             </div>
-        </>
+        </>;
     }
 }
 
@@ -62,13 +69,13 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => {
     return {
-        edit_event: (data) => dispatch(edit_event(data)),
+        edit_event: (data, onError, onSuccess) => dispatch(edit_event(data), onError, onSuccess),
         alert: (msg) => dispatch(setSuccessAllert(msg)),
-    }
+    };
 };
 
 export default withRouter(connect(
-    mapStateToProps, 
+    mapStateToProps,
     mapDispatchToProps
 )(EditEventWrapper));
 

--- a/EventsExpress/ClientApp/src/containers/edit-event.js
+++ b/EventsExpress/ClientApp/src/containers/edit-event.js
@@ -17,10 +17,8 @@ class EditEventWrapper extends Component {
             ...validateEventForm(values),
             user_id: this.props.user_id,
             id: this.props.event.id
-        }, async response => {
-            throw new SubmissionError(await buildValidationState(response));
         });
-        this.props.alert('Your event has been successfully saved!');
+
         this.props.history.goBack();
     };
 
@@ -69,8 +67,10 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => {
     return {
-        edit_event: (data, onError, onSuccess) => dispatch(edit_event(data), onError, onSuccess),
-        alert: (msg) => dispatch(setSuccessAllert(msg)),
+        edit_event: (data) => dispatch(edit_event(data, async response => {
+            throw new SubmissionError(await buildValidationState(response));
+        }, dispatch(setSuccessAllert(msg)))),
+        alert: (msg) => dispatch(setSuccessAllert(msg))
     };
 };
 

--- a/EventsExpress/ClientApp/src/containers/event-draft.js
+++ b/EventsExpress/ClientApp/src/containers/event-draft.js
@@ -8,7 +8,7 @@ import { getFormValues , isPristine} from 'redux-form';
 import { edit_event, publish_event} from '../actions/event/event-add-action';
 import { validateEventForm } from './event-validate-form'
 import { change_event_status } from '../actions/event/event-item-view-action';
-import { setSuccessAllert } from '../actions/alert-action';
+import { setErrorAlert, setSuccessAllert } from '../actions/alert-action';
 import Button from "@material-ui/core/Button";
 import IconButton from "@material-ui/core/IconButton";
 import './css/Draft.css';
@@ -32,6 +32,10 @@ class EventDraftWrapper extends Component {
         await this.props.delete(this.props.event.id, reason);
         this.props.alert('Your event has been successfully deleted!');
         this.props.history.goBack();
+    }
+
+    onError = error => {
+        this.props.errorAlert(error);
     }
 
     render() {
@@ -62,6 +66,7 @@ class EventDraftWrapper extends Component {
                     user_name={this.props.user_name}
                     all_categories={this.props.all_categories}
                     onSubmit={this.onPublish}
+                    onError={this.onError}
                     initialValues={this.props.event}
                     form_values={this.props.form_values}
                     haveReccurentCheckBox={true}
@@ -116,6 +121,7 @@ const mapDispatchToProps = (dispatch) => {
         publish: (data) => dispatch(publish_event(data)),
         get_categories: () => dispatch(get_categories()),
         alert: (msg) => dispatch(setSuccessAllert(msg)),
+        errorAlert: message => dispatch(setErrorAlert(message))
     }
 };
 

--- a/EventsExpress/Filters/EventsExpressExceptionFilterAttribute.cs
+++ b/EventsExpress/Filters/EventsExpressExceptionFilterAttribute.cs
@@ -19,6 +19,7 @@ namespace EventsExpress.Filters
                         { string.Empty, new[] { eventsExpressException.Message } },
                     },
                 };
+
                 if (eventsExpressException.ValidationErrors?.Count > 0)
                 {
                     foreach (var x in eventsExpressException.ValidationErrors)
@@ -33,10 +34,13 @@ namespace EventsExpress.Filters
             }
             else
             {
-                string message = "Unhandled exception occurred. Please try again. " +
-                    "If this error persists - contact system administrator.";
-                context.ModelState.AddModelError(string.Empty, message);
-                var result = new ObjectResult(context.ModelState) { StatusCode = 500 };
+                string message = "Unhandled exception occurred. Please try again. "
+                                 + "If this error persists - contact system administrator.";
+                var errors = new Dictionary<string, Array>
+                {
+                    { "_error", new[] { message } },
+                };
+                var result = new ObjectResult(new { Errors = errors }) { StatusCode = 500 };
                 context.Result = result;
                 context.ExceptionHandled = true;
             }

--- a/EventsExpress/Filters/EventsExpressExceptionFilterAttribute.cs
+++ b/EventsExpress/Filters/EventsExpressExceptionFilterAttribute.cs
@@ -16,7 +16,7 @@ namespace EventsExpress.Filters
                 {
                     Errors = new Dictionary<string, Array>()
                     {
-                        { string.Empty, new[] { eventsExpressException.Message } },
+                        { "_error", new[] { eventsExpressException.Message } },
                     },
                 };
 


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @sand0 
- [ ] @iuriikhrystiuk 

### Second Level Review

- [ ] @Neckral 

## Summary of issue

In 897 there was an error with saving new event, this issue was reproducable, when Azure Storage Emulator was turned off.
Because of this photo couldn't upload, and server returned 500 Internal Server Error.
This error wasn't properly handled in UI app and Unhandled Rejection page was shown

## Summary of change

First of all, I changed response object from server for 500 Internal Server Error, so its pattern will match to 400 Bad Request response object. This allowed me to refactor buildValidationState and getErrorMessage functions. Now getErrorMessage uses buildValidationState to get message with error. Also, I added error handling in event form for case, when there is global form error (_error).
Then I changed edit_event function. Originally it used SubmissionError to display errors, but this didn't work for click on save button, because SubmissionError is handled by redux-form when form is submitted, and form is submitting by publish button. It was hard to submit form with two buttons, so I used callbacks for error and success cases.

## Testing approach

ToDo

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions

#897 
#903 
