### PR TITLE
Fix Email Confirmation

### DIFF
--- a/EventsExpress.Core/Services/AuthService.cs
+++ b/EventsExpress.Core/Services/AuthService.cs
@@ -209,10 +209,6 @@ namespace EventsExpress.Core.Services
             account.AccountRoles = new[] { new AccountRole { RoleId = Db.Enums.Role.User } };
             var result = Insert(account);
             await Context.SaveChangesAsync();
-            var authLocal = Context.AuthLocal.FirstOrDefault(al => al.Id == result.AuthLocal.Id);
-            var existingAcc = Context.Accounts.FirstOrDefault(ec => ec.Id == result.Id);
-            existingAcc.UserId = authLocal.AccountId;
-            await Context.SaveChangesAsync();
             await _mediator.Publish(new RegisterVerificationMessage(account.AuthLocal));
 
             return result.Id;


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @iuriikhrystiuk 
- [ ] @sand0 

### Second Level Review

- [ ] @idontwannawakeup 

## Summary of issue

On registration via email process was throwing exception about null token because when there was send the request to get localAccountId the LINQ worked incorrect because the serch was by Id when it was supposed to be by AccountId.

## Summary of change

Fixed LINQ query. Changed search condition from Id to AccountId.

## Testing approach

ToDo

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
