### PR TITLE
fixedNulableEventOnPublish

### DIFF
--- a/EventsExpress.Core/Services/EventService.cs
+++ b/EventsExpress.Core/Services/EventService.cs
@@ -291,7 +291,7 @@ namespace EventsExpress.Core.Services
                .Include(e => e.StatusHistory)
                .Include(e => e.Categories)
                    .ThenInclude(c => c.Category)
-               .FirstOrDefault(x => x.Id == eventId);
+               .First(x => x.Id == eventId);
 
             ev.StatusHistory.Add(
                     new EventStatusHistory


### PR DESCRIPTION
dev
## GitHub Project

* [Main GitHub Project ticket](https://github.com/EventsExpress/EventsExpress/projects/2)


## Code reviewers

- [ ] @iuriikhrystiuk 
- [ ] @sand0 

### Second Level Review

- [ ] @D1mon007 

## Summary of issue

After merging 736, appeared an error becouse of nullabel on Publish from EventService because of task with nulabel fixing.

## Summary of change

Changed method from FirstOrDefault() to First().

## Testing approach

ToDo

## CHECK LIST
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
